### PR TITLE
Added partial support for BB7 devices

### DIFF
--- a/kWidgetLoader.js
+++ b/kWidgetLoader.js
@@ -303,9 +303,9 @@ var kWidget = {
 		//while ( targetNode.hasChildNodes() ) {
 		//   targetNode.removeChild( targetNode.lastChild );
 		//}
-		if(!options)
-			options = {};
-
+		if( typeof options == 'undefined' ) {
+			var options = {};
+		}
 		// look some other places for sizes:
 		if( !options.width && kEmbedSettings.width )
 			options.width = kEmbedSettings.width;
@@ -412,7 +412,7 @@ var kWidget = {
 	supportsHTML5: function(){
 		var dummyvid = document.createElement( "video" );
 		// Blackberry does not really support html5
-		if( navigator.userAgent.indexOf('BlackBerry') != -1 ){
+		if( ! kWidget.isBlackBerryHTML5Support() ){
 			return false;
 		}
 		if( dummyvid.canPlayType ) {
@@ -470,6 +470,18 @@ var kWidget = {
 		return ( (navigator.userAgent.indexOf('iPhone') != -1) ||
 		(navigator.userAgent.indexOf('iPod') != -1) ||
 		(navigator.userAgent.indexOf('iPad') != -1) );
+	 },
+	 
+	 /*
+	  * Checks for BlackBerry HTML5 support (version 7+)
+	  */
+	 isBlackBerryHTML5Support: function() {
+		var ua = navigator.userAgent;
+		if( ua.indexOf("BlackBerry") != -1 && ua.indexOf("Version/") != -1 ) {
+			var verPosition = ua.indexOf("Version/") + 8;
+            return ( parseInt(ua.substring(verPosition, verPosition + 3)) >= 7 ) ? true : false;
+		}
+		return false;
 	 },
 
 	 /*

--- a/modules/EmbedPlayer/mw.EmbedPlayer.js
+++ b/modules/EmbedPlayer/mw.EmbedPlayer.js
@@ -7,7 +7,7 @@
 * mw.PlayerControlBuilder Handles skinning of the player controls
 */
 
-( function( mw, $ ) { "use strict";
+( function( mw, $ ) {"use strict";
 
 /**
  * Add the messages text:
@@ -1401,7 +1401,7 @@ mw.EmbedPlayer.prototype = {
 
 		// Do some device detection devices that don't support overlays
 		// and go into full screen once play is clicked:
-		if( mw.isAndroid2() || mw.isIpod()  || mw.isIphone() ){
+		if( mw.isAndroid2() || mw.isIpod()  || mw.isIphone() || kWidget.isBlackBerryHTML5Support() ){
 			return true;
 		}
 		
@@ -1559,7 +1559,7 @@ mw.EmbedPlayer.prototype = {
 		}
 		// old style embed:
 		var iframeUrl = mw.getMwEmbedPath() + 'mwEmbedFrame.php?';
-		var params = { 'src[]' : [] };
+		var params = {'src[]' : []};
 
 		// TODO move to mediaWiki Support module
 		if( this.apiTitleKey ) {

--- a/mwEmbedLoader.js
+++ b/mwEmbedLoader.js
@@ -319,9 +319,9 @@ function kCheckAddScript(){
 
 	// Check if no flash and no html5 and no forceFlash ( direct download link )
 	// for debug purpose:
-	// kSupportsFlash = function() {return false}; kWidget.supportsHTML5 = function() {return false};
+	// kWidget.supportsFlash = function() {return false}; kWidget.supportsHTML5 = function() {return false};
 	if( ! kWidget.supportsFlash() && ! kWidget.supportsHTML5() && ! mw.getConfig( 'Kaltura.ForceFlashOnDesktop' ) ){
-		kAddScript();
+		kDoIframeRewriteList( kGetKalturaPlayerList() );
 		return ;
 	}
 	// Restore the jsCallbackReady ( we are not rewriting )


### PR DESCRIPTION
I've revisit our Blackberry support for v7+

With a sample video tag with h264 (iPhone flavor) It did worked sometimes.
I got the native player, and was able to playback the video. But sometimes after refresh it stopped working.

When I used the library to create the player, it didn't work at all, the player wasn't responsive.

Any idea guys?
