### PR TITLE
Double click no content resume

### DIFF
--- a/modules/DoubleClick/mw.DoubleClick.js
+++ b/modules/DoubleClick/mw.DoubleClick.js
@@ -618,7 +618,7 @@ mw.DoubleClick.prototype = {
 				vid.play();
 				_this.forceContentPlay();
 			}
-		}, 2000 );
+		}, 8000 );
 	},
 	/**
 	 * TODO should be provided by the generic ad plugin class. 


### PR DESCRIPTION
this adds a fallback for doubleclick content play. Should be merged. 
