### PR TITLE
Add support for customParams, fixes Ad api for iOS doPlay

### DIFF
--- a/modules/DoubleClick/mw.DoubleClick.js
+++ b/modules/DoubleClick/mw.DoubleClick.js
@@ -146,8 +146,8 @@ mw.DoubleClick.prototype = {
 				// Setup the restore callback
 				_this.restorePlayerCallback = callback;
 				// Request ads
-				mw.log( "DoubleClick:: addManagedBinding : requestAds:" +  _this.getConfig("adTagUrl")  );
-				_this.requestAds( unescape( _this.getConfig("adTagUrl") ) );	
+				mw.log( "DoubleClick:: addManagedBinding : requestAds:" +  _this.getAdTagUrl()  );
+				_this.requestAds( _this.getAdTagUrl() );	
 			};
 		});
 		_this.embedPlayer.bindHelper( 'AdSupport_postroll' + _this.bindPostfix, function( event, sequenceProxy ){
@@ -166,7 +166,24 @@ mw.DoubleClick.prototype = {
 			};
 		});
 	},
-	// get the content video tag
+	/**
+	 * Get the AdTagUrl append the custom params
+	 */
+	getAdTagUrl: function(){
+		var adUrl = this.getConfig( 'adTagUrl' );
+		if( !adUrl ){
+			return false;
+		}
+		var paramSeperator = adUrl.indexOf( '?' ) === -1 ? '?' : 
+			adUrl[ adUrl.length -1 ] == '&' ? '': '&';
+		var postFix = this.getConfig( 'customParams' ) ? 
+				'cust_params=' + encodeURIComponent( this.getConfig( 'customParams' ) ) : 
+				'';
+		return unescape( this.getConfig( 'adTagUrl' ) ) + paramSeperator + postFix;
+	},
+	/**
+	 * Get the content video tag
+	 */
 	getContent:function(){
 		// Set the content element to player element: 
 		return this.embedPlayer.getPlayerElement();
@@ -291,6 +308,9 @@ mw.DoubleClick.prototype = {
 	 // This function requests the ads.
 	requestAds: function( adTagUrl, adType ) {
 		var _this = this;
+		// Update the local lastRequestedAdTagUrl for debug and audits
+		_this.embedPlayer.setKDPAttribute( this.pluginName, 'requestedAdTagUrl', adTagUrl );
+		
 		// Create ad request object.
 		var adsRequest = {};
 		adsRequest.adTagUrl = adTagUrl;

--- a/modules/DoubleClick/tests/DoubleClickManagedPlayerAdApi.qunit.html
+++ b/modules/DoubleClick/tests/DoubleClickManagedPlayerAdApi.qunit.html
@@ -21,17 +21,26 @@ function jsKalturaPlayerTest( videoId ){
 			
 			start();
 			setTimeout(function(){
-				runPausePlayTests();
-			},100);
+				runValidateAdTag();
+			},500);
 		}
 		kalturaQunitWaitForPlayer(function(){
-			
 			// Listen for ad start
 			kdp.addJsListener( 'adStart', 'onAdStart' );
-			
 			// Send a play request:
 			kdp.sendNotification('doPlay');
 		});
+	});
+	asyncTest( "Validate ad tag url", function(){
+		window[ 'runValidateAdTag' ] = function(){
+			equal( 'http://pubads.g.doubleclick.net/gampad/ads?sz=400x300&iu=/6062/jeremy.site.video/BumpersAndAds&ciu_szs=300x250,728x90&impl=s&gdfp_req=1&env=vp&output=xml_vast2&unviewed_position_start=1&url=[referrer_url]&correlator=[timestamp]&vid=GxkABvaN2ms&cmsid=9884&ad_rule=1&cust_params=foo%3Dbar%26cat%3Dfish',
+					kdp.evaluate('{doubleClick.requestedAdTagUrl}'),
+					"Url matches requested ad tag url");
+			start();
+			setTimeout(function(){
+				runPausePlayTests();	
+			},100);
+		}
 	});
 	
 	asyncTest( "Ad pause play", function(){
@@ -47,7 +56,6 @@ function jsKalturaPlayerTest( videoId ){
 		window['onDoPause'] = function(){
 			kdp.removeJsListener( 'doPause', 'onDoPause' );
 			ok( true, "Recived doPause event" );
-			
 			kdp.addJsListener( 'doPlay', 'onDoPlay' );
 			setTimeout(function(){
 				kdp.sendNotification( 'doPlay' );
@@ -55,11 +63,8 @@ function jsKalturaPlayerTest( videoId ){
 		};
 		
 		window['runPausePlayTests'] = function(){
-			// play for one second: 
-			setTimeout(function(){
-				kdp.addJsListener( 'doPause', 'onDoPause' );
-				kdp.sendNotification('doPause');
-			},500);
+			kdp.addJsListener( 'doPause', 'onDoPause' );
+			kdp.sendNotification('doPause');
 		}
 	});
 	
@@ -67,7 +72,7 @@ function jsKalturaPlayerTest( videoId ){
 		window['onDoStop'] = function(){
 			ok( true, "Recived doStop event");
 			start();
-		});
+		};
 		window['runDoStopTest'] = function(){
 			kdp.addJsListener( 'doStop', 'onDoStop' );
 			kdp.sendNotification('doStop');	
@@ -85,27 +90,17 @@ all ad slots and overlays are loaded from server.
 <br /><br />
 <a href="?forceMobileHTML5"> Force Mobile HTML5</a> for testing with desktop chrome and safari.
 <br />
-<object id="kaltura_player_1316310055" 
-	name="kaltura_player_1316310055" 
-	type="application/x-shockwave-flash" 
-	allowFullScreen="true" 
-	allowNetworking="all" 
-	allowScriptAccess="always" 
-	height="330" width="400" 
-	bgcolor="#000000" 
-	xmlns:dc="http://purl.org/dc/terms/" 
-	xmlns:media="http://search.yahoo.com/searchmonkey/media/" 
-	rel="media:video" 
-	resource="http://www.kaltura.com/index.php/kwidget/cache_st/1231231246/wid/_243342/uiconf_id/7340952/entry_id/0_uka1msg4" 
-	data="http://www.kaltura.com/index.php/kwidget/cache_st/1231231246/wid/_243342/uiconf_id/7340952/entry_id/0_uka1msg4">
-		<param name="allowFullScreen" value="true" />
-		<param name="allowNetworking" value="all" />
-		<param name="allowScriptAccess" value="always" />
-		<param name="bgcolor" value="#000000" />
-		<param name="flashVars" value="&" />
-		<param name="movie" value="http://www.kaltura.com/index.php/kwidget/cache_st/1231231246/wid/_243342/uiconf_id/7340952/entry_id/0_uka1msg4" />
-</object>
-
+<div id="videoTarget" style="width:400px;height:330px"></div>
+<script>
+	kWidget.embed('videoTarget', {
+		'wid' : '_243342',
+		'uiconf_id' : '7340952',
+		'entry_id': '0_uka1msg4',
+		'flashvars' : {
+			'doubleClick.customParams' : 'foo=bar&cat=fish'
+		}
+	});
+</script>
 <!-- 
 <layout id="full" name="DoubleClick Managed" skinPath="/content/uiconf/kaltura/kmc/appstudio/kdp3/eagle/skin/v3.5.9/skin.swf">
   <HBox id="topLevel" width="100%" height="100%">
@@ -114,7 +109,8 @@ all ad slots and overlays are loaded from server.
       <Plugin id="statistics" width="0%" height="0%" includeInLayout="false"/>
       
       
-      <Plugin id="doubleClick" 
+      <Plugin id="doubleClick"
+      		customParams="section%3Dblog%26anotherKey%3Dvalue1%2Cvalue2" 
 	      	postSequence="0" 
 	      	preSequence="1" 
 			path="http://projects.kaltura.com/nu/wwwDoubleclick/plugins/doubleclickPlugin020512.swf"

--- a/modules/KalturaSupport/mw.KDPMapping.js
+++ b/modules/KalturaSupport/mw.KDPMapping.js
@@ -105,7 +105,7 @@
 						if( notificationName == 'doPlay' &&  mw.isIOS() ){
 							$( '#' + playerProxy.id + '_ifp' )
 								.get(0).contentWindow
-								.$( '#' + playerProxy.id ).get(0).play();
+								.$( '#' + playerProxy.id ).get(0).sendNotification( 'doPlay' );
 							// Do not also issue iframe postMessage ( so we avoid sending two play requests ) 
 							return false;
 						}


### PR DESCRIPTION
## Description

Adds support for customParams, fixes issue with ad api for doPlay
## Configuration

The customParams option can be configured via flashvar or uIConf as:

```
doubleClick.customParams = 'nameValue=pairs&to=be&appendedTo=adTagUrl"
```
## Testing
- This file can be tested with the  [automated test file](http://html5video.org/kgit/pulls/141/modules/DoubleClick/tests/DoubleClickManagedPlayerAdApi.qunit.html?runQunitTests=1) -- the addition of test  3 , Validate ad tag url (0, 1, 1) Validates the new customParams config option. 
- The issue with api doPlay can be tested by simply setting the user agent to iOS / iPad and re-running the same [automated test file](http://html5video.org/kgit/pulls/141/modules/DoubleClick/tests/DoubleClickManagedPlayerAdApi.qunit.html?runQunitTests=1)
