### PR TITLE
Widget ID is not the same as Partner ID

### DIFF
--- a/modules/KalturaSupport/KalturaResultObject.php
+++ b/modules/KalturaSupport/KalturaResultObject.php
@@ -24,6 +24,7 @@ class KalturaResultObject {
 	var $error = false;
 	// Set of sources
 	var $sources = null;
+	var $partnerId = null;
 	
 	// Local flag to store whether output was came from cache or was a fresh request
 	private $outputFromCache = false;
@@ -878,6 +879,12 @@ class KalturaResultObject {
 			$resultObject[ 'uiconf_id' ] = $this->urlParameters['uiconf_id'];
 			$resultObject[ 'uiConf' ] = $this->uiConfFile;
 		}
+		
+		// Set the partner id
+		if( $resultObject['meta']->partnerId ) {
+			$this->partnerId = $resultObject['meta']->partnerId;
+			$resultObject['partner_id'] = $resultObject['meta']->partnerId;
+		}
 
 		// Add Cue Point data. Also check for 'code' error
 		if( isset( $resultObject['entryCuePoints'] ) && is_object( $resultObject['entryCuePoints'] )
@@ -956,10 +963,10 @@ class KalturaResultObject {
 
 		$cacheDir = $wgScriptCacheDirectory;
 
-		$cacheFile = $this->getCacheDir() . '/' . $this->getPartnerId() . '.' . $this->getCacheSt() . ".ks.txt";
+		$cacheFile = $this->getCacheDir() . '/' . $this->getWidgetId() . '.' . $this->getCacheSt() . ".ks.txt";
 		$cacheLife = $wgKalturaUiConfCacheTime;
 
-		$conf = new KalturaConfiguration( $this->getPartnerId() );
+		$conf = new KalturaConfiguration( null );
 
 		$conf->serviceUrl = $this->getServiceConfig( 'ServiceUrl' );
 		$conf->serviceBase = $this->getServiceConfig( 'ServiceBase' );
@@ -986,6 +993,7 @@ class KalturaResultObject {
 				try{
 					$session = $client->session->startWidgetSession( $this->urlParameters['wid'] );
 					$this->ks = $session->ks;
+					$this->partnerId = $session->partnerId;
 					$this->putCacheFile( $cacheFile,  $this->ks );
 				} catch ( Exception $e ){
 					throw new Exception( KALTURA_GENERIC_SERVER_ERROR . "\n" . $e->getMessage() );
@@ -1009,9 +1017,11 @@ class KalturaResultObject {
 	public function getUiConfId(){
 		return $this->urlParameters[ 'uiconf_id' ];
 	}
+	public function getWidgetId() {
+		return $this->urlParameters['wid'];
+	}
 	public function getPartnerId(){
-		// Partner id is widget_id but strip the first character
-		return substr( $this->urlParameters['wid'], 1 );
+		return $this->partnerId;
 	}
 	public function getEntryId(){
 		return ( isset( $this->urlParameters['entry_id'] ) ) ? $this->urlParameters['entry_id'] : false;

--- a/modules/KalturaSupport/kalturaIframe.php
+++ b/modules/KalturaSupport/kalturaIframe.php
@@ -165,6 +165,7 @@ class kalturaIframe {
 				}
 			}
 		}
+		$o.= ' kpartnerid="' . $this->getResultObject()->getPartnerId() . '"';
 		if( $this->playerError !== false ){
 			// TODO should move this to i8ln keys instead of raw msgs
 			$o.= ' data-playerError="' . htmlentities( $this->playerError ) . '" ';

--- a/modules/KalturaSupport/kaltura_client_v3/KalturaClientBase.php
+++ b/modules/KalturaSupport/kaltura_client_v3/KalturaClientBase.php
@@ -229,7 +229,7 @@ class KalturaClientBase
 	public function queueServiceActionCall($service, $action, $params = array(), $files = array())
 	{
 		// in start session partner id is optional (default -1). if partner id was not set, use the one in the config
-		if (!isset($params["partnerId"]) || $params["partnerId"] === -1)
+		if (!isset($params["partnerId"]) || $params["partnerId"] === -1 || !is_null($this->config->partnerId))
 			$params["partnerId"] = $this->config->partnerId;
 			
 		$this->addParam($params, "ks", $this->ks);
@@ -971,7 +971,7 @@ class KalturaConfiguration
 	 */
 	public function __construct($partnerId = -1)
 	{
-	    if (!is_numeric($partnerId))
+	    if (!is_null($partnerId) && !is_numeric($partnerId))
 	        throw new KalturaClientException("Invalid partner id", KalturaClientException::ERROR_INVALID_PARTNER_ID);
 	        
 	    $this->partnerId = $partnerId;

--- a/modules/KalturaSupport/mw.KAnalytics.js
+++ b/modules/KalturaSupport/mw.KAnalytics.js
@@ -129,7 +129,7 @@ mw.KAnalytics.prototype = {
 			'eventTimestamp'	: new Date().getTime(),
 			'isFirstInSession'	: 'false',
 			'objectType'		: 'KalturaStatsEvent',
-			'partnerId'			: this.kClient.getPartnerId(),
+			'partnerId'			: this.embedPlayer.kpartnerid,
 			'sessionId'			: this.embedPlayer.evaluate('{configProxy.sessionId}'),
 			'uiconfId'			: 0
 		};				

--- a/modules/KalturaSupport/mw.KWidgetSupport.js
+++ b/modules/KalturaSupport/mw.KWidgetSupport.js
@@ -208,7 +208,7 @@ mw.KWidgetSupport.prototype = {
 				$('<source />')
 				.attr( {
 					'src' : kWidget.getKalturaThumbUrl({
-						'partner_id' : this.kClient.getPartnerId(),
+						'partner_id' : embedPlayer.kpartnerid,
 						'entry_id' : embedPlayer.kentryid,
 						'width' : embedPlayer.getWidth(),
 						'height' :  embedPlayer.getHeight()
@@ -649,7 +649,7 @@ mw.KWidgetSupport.prototype = {
 	 * accessible via static reference mw.getEntryIdSourcesFromApi
 	 * 
 	 */
-	getEntryIdSourcesFromApi:  function( widgetId, entryId, size, callback ){
+	getEntryIdSourcesFromApi:  function( widgetId, partnerId, entryId, size, callback ){
 		var _this = this;
 		var sources;
 		mw.log( "KWidgetSupport:: getEntryIdSourcesFromApi: w:" + widgetId + ' entry:' + entryId );
@@ -669,7 +669,7 @@ mw.KWidgetSupport.prototype = {
 			if( playerData.meta && playerData.meta.mediaType == 2 ){ 
 				sources = [{
 						'src' : kWidget.getKalturaThumbUrl({
-							'widget_id' : widgetId,
+							'partner_id' : partnerId,
 							'entry_id' : entryId,
 							'width' : size.width,
 							'height' : size.height
@@ -678,7 +678,7 @@ mw.KWidgetSupport.prototype = {
 					}];
 			} else {
 				// Get device sources 
-				sources = _this.getEntryIdSourcesFromPlayerData( _this.kClient.getPartnerId(), playerData );
+				sources = _this.getEntryIdSourcesFromPlayerData( partnerId, playerData );
 			}
 			// Return the valid source set
 			callback( sources );
@@ -721,7 +721,7 @@ mw.KWidgetSupport.prototype = {
 		var bootstrapData = mw.getConfig("KalturaSupport.IFramePresetPlayerData");
 		// Insure the bootStrap data has all the required info: 
 		if( bootstrapData 
-			&& bootstrapData.partner_id == embedPlayer.kwidgetid.replace( '_', '' )
+			&& bootstrapData.partner_id
 			&& bootstrapData.ks
 		){
 			mw.log( 'KWidgetSupport::loaded player data from KalturaSupport.IFramePresetPlayerData config' );
@@ -841,7 +841,7 @@ mw.KWidgetSupport.prototype = {
 		// Set the poster ( if not already set ) 
 		if( !embedPlayer.poster && embedPlayer.kentryid ){
 			embedPlayer.poster = kWidget.getKalturaThumbUrl({
-				'partner_id' : this.kClient.getPartnerId(),
+				'partner_id' : embedPlayer.kpartnerid,
 				'entry_id' : embedPlayer.kentryid,
 				'width' : embedPlayer.getWidth(),
 				'height' :  embedPlayer.getHeight()
@@ -853,7 +853,7 @@ mw.KWidgetSupport.prototype = {
 			return ;
 		}
 		// Else get sources from flavor data :
-		var flavorSources = _this.getEntryIdSourcesFromPlayerData( _this.kClient.getPartnerId(), playerData );
+		var flavorSources = _this.getEntryIdSourcesFromPlayerData( embedPlayer.kpartnerid, playerData );
 
 		// Check for prefered bitrate info
 		var preferedBitRate = embedPlayer.evaluate('{mediaProxy.preferedFlavorBR}' );
@@ -1171,8 +1171,8 @@ if( !window.kWidgetSupport ){
 /**
  * Register a global shortcuts for the Kaltura sources query
  */
-mw.getEntryIdSourcesFromApi = function( widgetId, entryId, size, callback ){
-	kWidgetSupport.getEntryIdSourcesFromApi( widgetId, entryId, size, callback);
+mw.getEntryIdSourcesFromApi = function( widgetId, partnerId, entryId, size, callback ){
+	kWidgetSupport.getEntryIdSourcesFromApi( widgetId, partnerId, entryId, size, callback);
 };
 
 })( window.mw, jQuery );

--- a/modules/KalturaSupport/mw.PlaylistHandlerKaltura.js
+++ b/modules/KalturaSupport/mw.PlaylistHandlerKaltura.js
@@ -475,7 +475,7 @@ mw.PlaylistHandlerKaltura.prototype = {
 			'width': size.width,
 			'height': size.height,
 			'entry_id' : clip.id,
-			'partner_id' : this.getKClient().getPartnerId()
+			'partner_id' : clip.partnerId
 		});
 	},
 	/** 

--- a/modules/KalturaSupport/uiConfComponents/bumperPlugin.js
+++ b/modules/KalturaSupport/uiConfComponents/bumperPlugin.js
@@ -54,7 +54,7 @@ window.bumperPlugin = function( embedPlayer, callback ){
 			'width': embedPlayer.getWidth(), 
 			'height': embedPlayer.getHeight()	
 		}
-		mw.getEntryIdSourcesFromApi( embedPlayer.kwidgetid, bumperConfig.bumperEntryID, size, function( sources ){
+		mw.getEntryIdSourcesFromApi( embedPlayer.kwidgetid, embedPlayer.kpartnerid, bumperConfig.bumperEntryID, size, function( sources ){
 			if( ! sources ){
 				// no sources error:
 				mw.log("Error: bumperPlugin: No sources for: " + embedPlayer.kwidgetid + ' entry: ' +  bumperConfig.bumperEntryID );


### PR DESCRIPTION
Until now we used the widget id (wid) as a partner id by removing the underscore "_"
This assumption is wrong!

We need to use the widget id only for creating new session. and the partner id for other stuff ( like generating URLs for thumbnail and flavors )

The kwidget URL where we take the parameters could look like this:
http://www.kaltura.co.cc/index.php/kwidget/wid/0_2ttnm2dy/uiconf_id/1827131/entry_id/0_0qhqdm6s

This pull request is needed to support this use case.
