### PR TITLE
UiConfResult: parse nested arrays in flashvars

### DIFF
--- a/modules/KalturaSupport/UiConfResult.php
+++ b/modules/KalturaSupport/UiConfResult.php
@@ -232,6 +232,8 @@ class UiConfResult {
 						foreach( $fvSet as $subKey => $subValue ){
 							$vars[ $fvKey . '.' . $subKey ] =  $this->utility->formatString( $subValue );
 						}
+					} elseif ( is_array( $fvSet ) ) {
+						$vars[ $fvKey ] = $fvSet;
 					} else {
 						$vars[ $fvKey ] = $this->utility->formatString( $fvValue );
 					}

--- a/modules/KalturaSupport/tests/ReplaceSources.qunit.html
+++ b/modules/KalturaSupport/tests/ReplaceSources.qunit.html
@@ -28,7 +28,7 @@ function jsKalturaPlayerTest( videoId ){
 		asyncTest("Title present", function(){
 			// Test page context config: 
 			ok( $iframe.find('.TopTitleScreen').length, "TopTitleScreen found" );
-			equal( $iframe.find('.TopTitleScreen').find( 'span' ).text(), 'FolgersCoffe.mpeg', "Text title match" );
+			equal( $iframe.find('.TopTitleScreen').find( 'span' ).text(), 'FolgersCoffee.mpeg', "Text title match" );
 			runSourceChecks();
 			start();
 		});


### PR DESCRIPTION
Currently the EmbedPlayer.ReplaceSources [workaround for live-stream playback on iOS](http://html5video.org/wiki/Kaltura_HTML5_Configuration#Directly_play_m3u8_live_stream_sources) does not work.

The original issue is #161.

To see that the workaround does not work, look at the [qunit test](http://html5video.org/kaltura-player/modules/KalturaSupport/tests/ReplaceSources.qunit.html) (lead with HTML5) you will get the error:

```
Error: Syntax error, unrecognized expression: [
```

@sowo successfully traced this error to the fact that the flashvar option was not parsed correctly when the player is initialised inside the iFrame. I hunted around for quite a bit for the correct place to fix this (there were quite a few changes since #161 so this wasn't obvious to me) and finally decided to fix it in UiConfResult.php.

Please not that I am not familiar with the project and I assume that you want to add more sanitation – but for lack of a recursive decode-function (at least I didn't see one) I tested this, for now, by simply using the decoded array without any further checks. Please let me know if you want this to be done differently (and how) – we would love to see this merged since we found no other way to play live streams on iOS.

I also fixed what I assumed to be a typo in the related test case – I hope that assumption was correct.
