### PR TITLE
Cr 88402 - expose the ad click url to a notification 

### DIFF
--- a/modules/KalturaSupport/tests/AdVastWrapper.html
+++ b/modules/KalturaSupport/tests/AdVastWrapper.html
@@ -28,7 +28,7 @@ function adClick(a) {
 kWidget.embed({
     'targetId': 'kaltura_player',
     'wid': '_423851',
-    'uiconf_id' : '3066451',
+    'uiconf_id' : '15024512',
     'entry_id' : '1_67wtprz4',
     'flashvars': {
     	'externalInterfaceDisabled' : false ,


### PR DESCRIPTION
here's how to implement the JS code: 

function jsCallbackReady ( playerId ) {
    player = document.getElementById(playerId);
    player.addJsListener("adClick", "adClick");

}
function adClick(a) {
    console.log("ad url:" + a.url);
}
