### PR TITLE
VAST: remove potential legacy code which interrupts content playback

### DIFF
--- a/modules/KalturaSupport/resources/mw.KAdPlayer.js
+++ b/modules/KalturaSupport/resources/mw.KAdPlayer.js
@@ -83,14 +83,6 @@ mw.KAdPlayer.prototype = {
 				if( _this.embedPlayer.isImagePlayScreen() ){
 					_this.embedPlayer.getInterface().find( '.play-btn-large' ).remove()
 				}
-			
-				// if a preroll rewind to start:
-				/* NU: potentially legacy code that interrupted playback to play prerolls.
-				 * This causes the clip to play a few seconds of content after the vast ad completes. 
-				if( adSlot.type == 'preroll' ){
-					 _this.embedPlayer.setCurrentTime( .01);
-				}
-				*/
 
 				// Restore overlay if hidden:
 				if( $( '#' + _this.getOverlayId() ).length ){


### PR DESCRIPTION
This causes the clip to play a few seconds of content after completing ad playback. 
