### PR TITLE
Enhanced playback rate

### DIFF
--- a/modules/KalturaSupport/resources/uiConfComponents/playbackRateSelector.js
+++ b/modules/KalturaSupport/resources/uiConfComponents/playbackRateSelector.js
@@ -17,10 +17,6 @@
 					$speedMenu.append(
 						$.getLineItem( speedFloat + 'x', icon,function(){
 							prsPlugin.setSpecificSpeed(speedFloat);
-							// var vid = embedPlayer.getPlayerElement();
-							// vid.playbackRate = speedFloat;
-							// prsPlugin.currentSpeed = speedFloat;
-							// prsPlugin.updateNewSpeed();
 						})
 					);
 				})
@@ -50,6 +46,8 @@
 				prsPlugin.currentSpeed = newSpeed;
 				embedPlayer.getPlayerElement().playbackRate = prsPlugin.currentSpeed;
 				prsPlugin.updateNewSpeed();
+				var kdp = document.getElementById( embedPlayer.id );
+				kdp.sendNotification( 'updatedPlaybackRate', newSpeed);
 
 			},
 			'getCurrentSpeedIndex':function(){

--- a/modules/KalturaSupport/tests/PlaybackRate.qunit.html
+++ b/modules/KalturaSupport/tests/PlaybackRate.qunit.html
@@ -19,6 +19,7 @@ function jsKalturaPlayerTest( videoId ){
 Note not all HTML5 browsers support playback rate. 
 
 <div id="myVideoTarget" style="width:400px;height:330px;"></div>
+<br>
 <div>
 	<button class="btn-info btn btn-mini" onClick="slowest()"><i class="icon-white icon-fast-backward"></i> slowest</button>
 	<button class="btn-info btn btn-mini" onClick="slower()"><i class="icon-white icon-backward"></i> slower</button>
@@ -65,9 +66,13 @@ Note not all HTML5 browsers support playback rate.
 	});
 	kWidget.addReadyCallback( function( playerId ){
 		player = document.getElementById( playerId );
+		player.kBind('updatedPlaybackRate', function(newRate){
+				$("#changeLog").append( "Set playback rate to x" + newRate + "\n" );
+			});
 	});
 </script>
-
+Change log:
+<pre style="max-width:800px" id="changeLog"></pre>
 <p><p>
 <!-- 
 <b> Slow loading document.write scripts </b>


### PR DESCRIPTION
Added 2 API functions to the feature: 

1- setNextOrPrevSpeed – add the ability to set the video play faster or slower. This notification gets a delta argument (e.g. 1 to play the video faster than current played speed, -1 to play it slower than current played speed) 
2- setSpecificSpeed – sets playback speed to a specific speed by an argument. This API assumes that the new speed is in part of the optional speeds that were configured in the ‘speeds’ attribute.  

The test page now has 3 additional buttons - faster, slower and reset to show the new API abilities.
mwEmbed/modules/KalturaSupport/tests/PlaybackRate.qunit.html 
