### PR TITLE
SUP-1821 #fixed object re-write IE8 for DOM ready before flash load

### DIFF
--- a/kWidget/kWidget.js
+++ b/kWidget/kWidget.js
@@ -222,7 +222,7 @@ var kWidget = {
 		}
 
 		var player = document.getElementById( widgetId );
-		if( !player ){
+		if( !player || !player.evaluate ){
 			this.callJsCallback();
 			this.log("Error:: jsCallbackReady called on invalid player Id:" + widgetId );
 			return ;
@@ -328,7 +328,11 @@ var kWidget = {
 			return ;
 		}
 		// Empty the target ( don't keep SEO links on Page while loading iframe )
-		elm.innerHTML = '';
+		try{
+			elm.innerHTML = '';
+		} catch ( e ){
+			// IE8 can't handle innerHTML on "read only" targets .
+		}
 		
 		// Check for size override in kWidget embed call
 		function checkSizeOveride( dim ){


### PR DESCRIPTION
- this inherently flashes the "flash" version of the player briefly
  before being rewritten into HTML5, this is normal given the legacy embed
  is an object in DOM that the player will load.
