### PR TITLE
Fec 1219

### DIFF
--- a/modules/KalturaSupport/components/share/share.js
+++ b/modules/KalturaSupport/components/share/share.js
@@ -33,7 +33,6 @@ mw.PluginManager.add( 'share', mw.KBaseScreen.extend({
             default:
                 shareURL = this.getConfig("socialShareURL");
 		}
-
 		if( shareURL ) {
 			this.setConfig('shareURL', shareURL);
 		}


### PR DESCRIPTION
This fix is for Jira ticket FEC-1219 where the end user could not copy custom URL in the share plugin. 
