### PR TITLE
Removed player selection logic from player.kaltura.com

### DIFF
--- a/docs/css/kdoc.css
+++ b/docs/css/kdoc.css
@@ -404,26 +404,6 @@ a:hover .kpcicon-html5, .active .kpcicon-html5{
 a:hover .kpcicon-flash, .active .kpcicon-flash{
 	background-position: 0px -131px;
 }
-#playbackModeSelector{
-	clear:both;
-	width: 300px;
-	height: 40px;
-	position:relative;
-	padding:5px;
-	display: block
-}
-#playbackModeSelector button.left{
-	border-top-right-radius: 0px;
-	border-bottom-right-radius: 0px;
-}
-#playbackModeSelector button.right{
-	border-top-left-radius: 0px;
-	border-bottom-left-radius: 0px;
-}
-#playbackModeSelector span{
-	position: relative;
-	top:5px;
-}
 .feature-config{
 	padding-top: 14px;
 }

--- a/docs/js/doc-bootstrap.js
+++ b/docs/js/doc-bootstrap.js
@@ -110,6 +110,8 @@ $(document).on('click',  '.kdocUpdatePlayer', function(){
 if( ! localStorage.kdocEmbedPlayer ){
 	localStorage.kdocEmbedPlayer = 'html5';
 }
+// always disable playback-mode selector ( v2 ) 
+// now only pages with disablePlaybackModeSelector set LeadWithHTML5 to false, and require forceMobileHTML5
 if( !window['disablePlaybackModeSelector'] ){
 	// don't set flag if any special properties are set: 
 	if( localStorage.kdocEmbedPlayer == 'html5' && window['mw'] && 
@@ -119,63 +121,6 @@ if( !window['disablePlaybackModeSelector'] ){
 	){
 		mw.setConfig('Kaltura.LeadWithHTML5', true);
 	}
-}
-function updatePlaybackModeSelector( $target ){
-	if( window['disablePlaybackModeSelector'] ){
-		return;
-	}
-	if( ! $target ){
-		$target = $('#playbackModeSelector');
-	}
-	$target.empty().append(
-		$('<button>').attr({
-			'type': 'button',
-			'title': "Lead with the HTML5 player"
-		})
-		.addClass('btn left')
-		.append(
-			$('<i>').addClass('kpcicon-html5'),
-			$('<span>').text("HTML5 Player")
-		).click(function(){
-			if( !kWidget.supportsHTML5() ){
-				return ;
-			}
-			localStorage.kdocEmbedPlayer = 'html5';
-			location.reload();
-			return false;
-		}),
-		
-		$('<button>').attr({
-			'href': '#',
-			'title': "Lead with Flash player where available"
-		})
-		.addClass('btn right')
-		.append(
-			$('<i>').addClass('kpcicon-flash'),
-			$('<span>').text( "Flash Player")
-		).click(function(){
-			if( !kWidget.supportsFlash() ){
-				return ;
-			}
-			localStorage.kdocEmbedPlayer = 'flash';
-			location.reload()
-			return false;
-		})
-	)
-	if( !kWidget.supportsHTML5() ){
-		$target.find( '.kpcicon-html5' ).parent().addClass('disabled').attr('title',
-				"HTML5 is not supported on this browser");
-	}
-	if( !kWidget.supportsFlash() ){
-		$target.find( '.kpcicon-flash' ).parent().addClass('disabled').attr('title',
-				"Flash is not supported on this device");
-	}
-	if( localStorage.kdocEmbedPlayer == 'html5' && kWidget.supportsHTML5() ){
-		$target.find( '.kpcicon-html5' ).parent().addClass('active');
-	} else {
-		$target.find( '.kpcicon-flash' ).parent().addClass('active');
-	};
-	return $target;
 }
 
 // document ready events:
@@ -192,9 +137,6 @@ $(function(){
 		// invoke the pref menu
 		return false;
 	})
-	
-	updatePlaybackModeSelector( $('#playbackModeSelector') );
-	
 	
 	// make code pretty
 	window.prettyPrint && prettyPrint();

--- a/docs/js/jquery.prettyKalturaConfig.js
+++ b/docs/js/jquery.prettyKalturaConfig.js
@@ -1291,16 +1291,7 @@
 					}
 				});
 				
-				var $playbackModeSelector = $('<div>')
-					.attr("id", "playbackModeSelector" )
-					.css('float', 'right');
-				
-				updatePlaybackModeSelector( $playbackModeSelector );
-				
-				$textDesc = $('<div />').append(
-					// the player switcher: 
-					$playbackModeSelector
-				)
+				$textDesc = $('<div />')
 				
 				if( manifestData[ pluginName ] ){
 					if( manifestData[ pluginName ]['description']  ){

--- a/docs/main_content.php
+++ b/docs/main_content.php
@@ -34,10 +34,6 @@
 	<a href="#Performance">loading speed.</a> 
 	<br>
 	<br>
-	<div id="playbackModeSelector" style="float:right"></div>
-	<script>
-	updatePlaybackModeSelector( $('#playbackModeSelector') );
-	</script>
 	Every feature is supported for both both HTML5 and Flash with 
 	the same configuration, bringing <strong>unparalleled</strong> ease of feature integration across platforms.
 	We invite to explore the vast feature set of the Kaltura Player on your Tablets and Mobile Devices, 

--- a/docs/marketing_advertising.php
+++ b/docs/marketing_advertising.php
@@ -1,10 +1,6 @@
 <div id="hps-advertising"></div>
 <h1>Advertising and Monetization</h1>
 <p class="header">The Kaltura Player is compliant with all VAST supported ad-servers and pre-integrated with ecommerce, pay-per-view preview and paywall solutions.</p>
-<div id="playbackModeSelector" style="float:right"></div>
-<script>
-updatePlaybackModeSelector( $('#playbackModeSelector') );
-</script>
 <h3>Pre-Roll, Mid-Roll, Post-Roll Advertising</h3>
 <div id="prepost" style="width:400px;height:300px"></div>
 <script>

--- a/docs/marketing_customersamples.php
+++ b/docs/marketing_customersamples.php
@@ -1,8 +1,4 @@
 <div id="hps-customersamples"></div>
-<div id="playbackModeSelector" style="float:right"></div>
-<script>
-updatePlaybackModeSelector( $('#playbackModeSelector') );
-</script>
 <h1>Customer Player Samples</h1>
 <div class="entry-content">
   	<p class="header">The Kaltura Dynamic Player (KDP) can be modified with the Studio, with the UIconf (XML) or with the API. Below are some examples of how our customers have themselves (or in collaboration with Kaltura) made their player unique to their brand and business.</p>

--- a/docs/marketing_templates.php
+++ b/docs/marketing_templates.php
@@ -1,8 +1,4 @@
 <div id="hps-templates"></div>
-<div id="playbackModeSelector" style="float:right"></div>
-<script>
-updatePlaybackModeSelector( $('#playbackModeSelector') );
-</script>
 <h1>Standard Player Templates</h1>
 <div class="entry-content">
 	<p class="header">There are more then a dozen player templates pre-configured inside the KMC (in the Studio Tab). Once a template is selected, build out your player with simple point-and-click selections of colors, buttons, player sizes, ad configurations, etc.</p>

--- a/kWidget/onPagePlugins/chapters/ChapterSamples.html
+++ b/kWidget/onPagePlugins/chapters/ChapterSamples.html
@@ -372,7 +372,7 @@ on the <a href="chaptersView.qunit.html" title="chapters integration">chapters i
 
 
 </div>
-<div id="playbackModeSelector"></div>
+
 
 
 </body>

--- a/kWidget/onPagePlugins/chapters/chaptersSamples.css
+++ b/kWidget/onPagePlugins/chapters/chaptersSamples.css
@@ -86,9 +86,3 @@ pre.prettyprint {
 	margin-bottom: 5px;
 }
 
-#playbackModeSelector {
-	border-top: 1px solid #EEE;
-	padding-top: 10px;
-	margin-top: 40px;
-}
-

--- a/modules/AdSupport/tests/IntegrationSequenceProxyVastDoubleClick.html
+++ b/modules/AdSupport/tests/IntegrationSequenceProxyVastDoubleClick.html
@@ -40,7 +40,7 @@ function jsKalturaPlayerTest( videoId ){
 </head>
 <body>
 <h2>Integration Sequence Proxy Vast DoubleClick test </h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 <object id="kaltura_player" name="kaltura_player" type="application/x-shockwave-flash" allowFullScreen="true" 
 allowNetworking="all" allowScriptAccess="always" height="333" width="400" xmlns:dc="http://purl.org/dc/terms/" 

--- a/modules/Conviva/tests/Conviva.html
+++ b/modules/Conviva/tests/Conviva.html
@@ -12,7 +12,7 @@
 
 <body>
     <h3>Conviva Module</h3>
-    <p><div id="playbackModeSelector"></div></p>
+    <p></p>
     
     <p>
         Simply enabling the Conviva plugin via flashVars.<br />

--- a/modules/DoubleClick/tests/DoubleClickAdPattern.html
+++ b/modules/DoubleClick/tests/DoubleClickAdPattern.html
@@ -22,7 +22,7 @@ function jsKalturaPlayerTest( videoId ){
 <h2> DoubleClick Playlist AdPattern test </h2>
 
 Set ad pattern CAC ( content ad content -> content ad content )<br>
-<div id="playbackModeSelector"></div>
+
 <br />
 
 <object id="kaltura_player_1316977410" name="kaltura_player_1316977410"

--- a/modules/DoubleClick/tests/DoubleClickPlayer.html
+++ b/modules/DoubleClick/tests/DoubleClickPlayer.html
@@ -48,7 +48,7 @@ Should display: ( view source for uiconf )
 <li>postroll on clip done</li>
 </ul>
 </br>
-<div id="playbackModeSelector"></div>
+
 <br />
 <object id="kaltura_player_1316310055" 
 	name="kaltura_player_1316310055" 

--- a/modules/DoubleClick/tests/DoubleClickPlaylist.html
+++ b/modules/DoubleClick/tests/DoubleClickPlaylist.html
@@ -19,7 +19,7 @@ function jsKalturaPlayerTest( videoId ){
 </head>
 <body>
 <h2> DoubleClick Playlist test </h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 
 <object id="kaltura_player_1316977410" name="kaltura_player_1316977410"

--- a/modules/DoubleClick/tests/iPhoneCompatibleDoubleClickPreroll.html
+++ b/modules/DoubleClick/tests/iPhoneCompatibleDoubleClickPreroll.html
@@ -36,7 +36,7 @@ $(function(){
 <body>
 <h2> Iphone Compatible preroll DoubleClick ( only preroll ) </h2>
 <br /><br />
-<div id="playbackModeSelector"></div>
+
 <br />
 <object id="kaltura_player" 
 	name="kaltura_player" 

--- a/modules/KalturaSupport/tests/AccessControlCountry.html
+++ b/modules/KalturaSupport/tests/AccessControlCountry.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <h2> Access control - country restriction </h2>
-<div id="playbackModeSelector"></div>
+
 <div id="myVideoTarget" style="width:400px;height:330px;float:left">
 </div>
 <script type="text/javascript" src="resources/qunit-kaltura-bootstrap.js"></script>

--- a/modules/KalturaSupport/tests/AccessControlCustomMessage.html
+++ b/modules/KalturaSupport/tests/AccessControlCustomMessage.html
@@ -32,7 +32,7 @@ Custom access control messages can be set in the uiConf strings section:
 <pre class="prettyprint linenums">
 &lt;strings&gt;<br/>    &lt;string key=&quot;NO_KS&quot;  value=&quot;My NO_KS UiConf String&quot; /&gt;<br/>&lt;/strings&gt;
 </pre>
-<div id="playbackModeSelector"></div>
+
 <br />
 <object id="kaltura_player" name="kaltura_player" type="application/x-shockwave-flash" allowFullScreen="true" 
 allowNetworking="all" allowScriptAccess="always" height="333" width="400" xmlns:dc="http://purl.org/dc/terms/" 

--- a/modules/KalturaSupport/tests/AccessControlKS.html
+++ b/modules/KalturaSupport/tests/AccessControlKS.html
@@ -10,7 +10,7 @@
 <body>
 <h2> Access Control with KS </h2>
 <h3>Passing the player KS using flashvar and loading Thumbnails with KS</h3>
-<div id="playbackModeSelector"></div>
+
 <br />
 <object id="kaltura_player_1311514900" name="kaltura_player_1311514900"
  type="application/x-shockwave-flash" allowFullScreen="true" allowNetworking="all" 

--- a/modules/KalturaSupport/tests/AccessControlNewApi.qunit.html
+++ b/modules/KalturaSupport/tests/AccessControlNewApi.qunit.html
@@ -31,7 +31,7 @@ function jsKalturaPlayerTest( videoId ){
 <body>
 <h2> Access Control with New API </h2>
 <h3> This test uses the actions/messages access control api to block the player and display custom message</h3>
-<div id="playbackModeSelector"></div>
+
 <br />
 <div id="kdp" style="width:640px;height:480px;"></div>
 <script type="text/javascript">

--- a/modules/KalturaSupport/tests/AccessControlPlaylistBlockMobileFirstEntry.qunit.html
+++ b/modules/KalturaSupport/tests/AccessControlPlaylistBlockMobileFirstEntry.qunit.html
@@ -33,7 +33,7 @@ Demonstrates robust access control across playlist and devices.
 <br>
 In this Demo the first entry is blocked when played on mobile devices.  
 
-<div id="playbackModeSelector"></div>
+
 <br />
 <div id="kaltura_player" style="width:400px;height:680px"></div>
 <script>

--- a/modules/KalturaSupport/tests/AccessControlPlaylistBlockMobileSecondEntry.qunit.html
+++ b/modules/KalturaSupport/tests/AccessControlPlaylistBlockMobileSecondEntry.qunit.html
@@ -29,7 +29,7 @@ function jsKalturaPlayerTest( videoId ){
 </head>
 <body>
 <h2> AccessControl Playlist Block Mobile First Entry Test </h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 
 <object id="kaltura_player" 

--- a/modules/KalturaSupport/tests/AccessControlPreviewEmbedLevelKS.qunit.html
+++ b/modules/KalturaSupport/tests/AccessControlPreviewEmbedLevelKS.qunit.html
@@ -50,7 +50,7 @@ function jsKalturaPlayerTest( videoId ){
 </head>
 <body>
 <h2> Access Control Preview embed level ks </h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 <div id="playerTarget" style="width:400px;height:330px;"> loading ... </div>
 <script>

--- a/modules/KalturaSupport/tests/AccessControlTest.html
+++ b/modules/KalturaSupport/tests/AccessControlTest.html
@@ -12,7 +12,7 @@
 </head>
 <body>
 <h2> Access Control </h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 Kaltura.org Test<br />
 <object id="kaltura_player" name="kaltura_player" type="application/x-shockwave-flash" allowFullScreen="true" allowNetworking="all" allowScriptAccess="always" height="333" width="400" xmlns:dc="http://purl.org/dc/terms/" xmlns:media="http://search.yahoo.com/searchmonkey/media/" rel="media:video" resource="http://www.kaltura.com/index.php/kwidget/cache_st/1291823640/wid/_243342/uiconf_id/12905712/entry_id/1_8c3s1pvx" data="http://www.kaltura.com/index.php/kwidget/cache_st/1291823640/wid/_243342/uiconf_id/12905712/entry_id/1_8c3s1pvx"><param name="allowFullScreen" value="true" /><param name="allowNetworking" value="all" /><param name="allowScriptAccess" value="always" /><param name="bgcolor" value="#000000" /><param name="flashVars" value="&" /><param name="movie" value="http://www.kaltura.com/index.php/kwidget/cache_st/1291823640/wid/_243342/uiconf_id/12905712/entry_id/1_8c3s1pvx" /><a href="http://corp.kaltura.com">video platform</a> <a href="http://corp.kaltura.com/video_platform/video_management">video management</a> <a href="http://corp.kaltura.com/solutions/video_solution">video solutions</a> <a href="http://corp.kaltura.com/video_platform/video_publishing">video player</a> <a rel="media:thumbnail" href="http://cdnbakmi.kaltura.com/p/423851/sp/42385100/thumbnail/entry_id/1_8c3s1pvx/width/120/height/90/bgcolor/000000/type/2" /> <span property="dc:description" content="" /><span property="media:title" content="Normal web quality video (400kbps)" /> <span property="media:width" content="400" /><span property="media:height" content="333" /> <span property="media:type" content="application/x-shockwave-flash" /> </object><br /><br />	

--- a/modules/KalturaSupport/tests/AgeGate.html
+++ b/modules/KalturaSupport/tests/AgeGate.html
@@ -8,7 +8,7 @@
 <body>
 <h2> Age Gate test </h2>
 Renders an "age gate" form where the user must supply their age before they can access the content. <br />
-<div id="playbackModeSelector"></div>
+
 <br /><br />
 
 <div id="player" style="width: 480px; height: 330px;"></div>

--- a/modules/KalturaSupport/tests/AlertForCookies.qunit.html
+++ b/modules/KalturaSupport/tests/AlertForCookies.qunit.html
@@ -41,7 +41,7 @@
 <body>
 	<h2> User allows/disallows saving cookies </h2>
 	<div id="afcConfig"></div>
-	<div id="playbackModeSelector"></div>
+	
 	<br /><br />
 	<div id="myVideoTarget" style="width:400px;height:330px;float:left">
 	</div>

--- a/modules/KalturaSupport/tests/AnnotationTest.html
+++ b/modules/KalturaSupport/tests/AnnotationTest.html
@@ -8,7 +8,7 @@
 </head>
 <body>
 <h2> Annotation Demo </h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 <div id="myVideoTarget" style="width:640px;height:540px;float:left">
 </div>

--- a/modules/KalturaSupport/tests/AudioEntryPlayer.qunit.html
+++ b/modules/KalturaSupport/tests/AudioEntryPlayer.qunit.html
@@ -33,7 +33,7 @@
 </head>
 <body>
 	<h2> Audio Player MP3 Flavor Test </h2>
-	<div id="playbackModeSelector"></div>
+	
 	<br />
 	<div id="kaltura_player" style="width:400px;height:55px;"></div>
 	<script>

--- a/modules/KalturaSupport/tests/AudioPlaylist.html
+++ b/modules/KalturaSupport/tests/AudioPlaylist.html
@@ -9,7 +9,7 @@
 </head>
 <body>
 <h2> Audio Playlist </h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 
 

--- a/modules/KalturaSupport/tests/AudioVisualizeFlash.html
+++ b/modules/KalturaSupport/tests/AudioVisualizeFlash.html
@@ -10,28 +10,26 @@ window['disablePlaybackModeSelector'] = true;
 <script type="text/javascript" src="../../../mwEmbedLoader.php"></script>
 <script type="text/javascript" src="../../../docs/js/doc-bootstrap.js"></script>
 
-
-
 </head>
 <body>
 <div id="audio" style="width:480px;height:130px" ></div>
 <script type="text/javascript" src="resources/qunit-kaltura-bootstrap.js"></script>
 <script>
 	var flashvars = {
-			'SoundVisualize': {
-				'plugin' : 'true',
-				'path' : '/content/uiconf/ps/demos/kdp3/plugins/v3.5.6/SoundVisualizePlugin.swf',
-				'width' : '100%',
-				'height' : '100%',
-				'relativeTo': 'video',
-				'position': 'after',
-			} , 
-			'onVideoPlayBtnStartScreen.visible' : 'false',
-			'onVideoPlayBtnPauseScreen.visible' : 'false',
-			'fullScreenBtnControllerScreen.visible' : 'false',
-			'fullScreenBtnControllerScreen.includeInLayout' : 'false',
-			'video.visible' : 'false',
-			'volumeBar.layoutMode' : 'horizontal'
+		'SoundVisualize': {
+			'plugin' : 'true',
+			'path' : '/content/uiconf/ps/demos/kdp3/plugins/v3.5.6/SoundVisualizePlugin.swf',
+			'width' : '100%',
+			'height' : '100%',
+			'relativeTo': 'video',
+			'position': 'after',
+		} , 
+		'onVideoPlayBtnStartScreen.visible' : 'false',
+		'onVideoPlayBtnPauseScreen.visible' : 'false',
+		'fullScreenBtnControllerScreen.visible' : 'false',
+		'fullScreenBtnControllerScreen.includeInLayout' : 'false',
+		'video.visible' : 'false',
+		'volumeBar.layoutMode' : 'horizontal'
 	};
 	function doEmbedPlayer( fv ){
 		// clear the companions 

--- a/modules/KalturaSupport/tests/AutoPlay.qunit.html
+++ b/modules/KalturaSupport/tests/AutoPlay.qunit.html
@@ -51,7 +51,7 @@ and just displays the play button.
 kWidget.embed({<br/>	'targetId': 'kaltura_player',<br/>	'wid': '_243342',<br/>	'uiconf_id' : '12905712',<br/>	'entry_id' : '0_uka1msg4',<br/>	'flashvars': {<br/>		'autoPlay': true<br/>	}<br/>});
 </pre>
 <br />
-<div id="playbackModeSelector"></div>
+
 <div id="kaltura_player" style="width:400px;height:330px;"></div>
 <script>
 kWidget.embed({

--- a/modules/KalturaSupport/tests/BufferEvents.qunit.html
+++ b/modules/KalturaSupport/tests/BufferEvents.qunit.html
@@ -119,7 +119,7 @@ kWidget.addReadyCallback(function(playerId){
 })
 </pre>
 <br />
-<div id="playbackModeSelector"></div>
+
 <object id="kaltura_player_1330021939" 
 	name="kaltura_player_1330021939" 
 	type="application/x-shockwave-flash" 

--- a/modules/KalturaSupport/tests/BumperAdTest.html
+++ b/modules/KalturaSupport/tests/BumperAdTest.html
@@ -9,7 +9,7 @@
 </head>
 <body>
 <h2> Preroll ad + Preroll Bumper </h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 <object id="kaltura_player" name="kaltura_player" 
 	type="application/x-shockwave-flash" allowFullScreen="true" 

--- a/modules/KalturaSupport/tests/BuyNow.html
+++ b/modules/KalturaSupport/tests/BuyNow.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <h2>E-commerce player</h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 <div id="myVideoTarget" style="width:400px;height:330px;float:left">
 </div>

--- a/modules/KalturaSupport/tests/ChangeMediaEntry.qunit.html
+++ b/modules/KalturaSupport/tests/ChangeMediaEntry.qunit.html
@@ -91,7 +91,7 @@ Change Media Log: <pre style="max-width:800px" id="changeLog"></pre>
 <input class="changeMedia" type="button" data-entryId="0_wm82kqmm" value="Entry 2 electric sheep" />
 <input class="changeMedia" type="button" data-entryId="0_59x7sgqo" value="Entry 3 Kaltura logo" />
 <br><br>
-<div id="playbackModeSelector"></div>
+
 <div id="kaltura_player" style="height:333px;width:400px"></div>
 
 <script>

--- a/modules/KalturaSupport/tests/CuePointsAds.html
+++ b/modules/KalturaSupport/tests/CuePointsAds.html
@@ -18,7 +18,7 @@
 	<li>02:38 - Postroll</li>
 </ul>
 
-<div id="playbackModeSelector"></div>
+
 <br /><br />
 
 <div id="myVideoTarget" style="width:400px;height:330px;"></div>

--- a/modules/KalturaSupport/tests/CustomNotifications.qunit.html
+++ b/modules/KalturaSupport/tests/CustomNotifications.qunit.html
@@ -31,7 +31,7 @@ function jsKalturaPlayerTest( videoId ){
 </head>
 <body>
 <h2> Custom Notifications </h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 
 <div id="myVideoTarget" style="width:400px;height:330px;">

--- a/modules/KalturaSupport/tests/DownloadLinkPlayer.qunit.html
+++ b/modules/KalturaSupport/tests/DownloadLinkPlayer.qunit.html
@@ -67,7 +67,7 @@ To enable the download link player you need to set a few flags:
 	// Enable the download link player: 
 	mw.setConfig( 'EmbedPlayer.NotPlayableDownloadLink', true );
 </pre>
-<div id="playbackModeSelector"></div>
+
 <br />
 
 <div id="kaltura_player" style="width:400px;height:330px"></div>

--- a/modules/KalturaSupport/tests/DownloadMedia.html
+++ b/modules/KalturaSupport/tests/DownloadMedia.html
@@ -8,7 +8,7 @@
 </head>
 <body>
 <h2> Download Media </h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 <object id="kaltura_player_1327841730"
 	name="kaltura_player_1327841730"

--- a/modules/KalturaSupport/tests/EmbedSWFObject.2.2.qunit.html
+++ b/modules/KalturaSupport/tests/EmbedSWFObject.2.2.qunit.html
@@ -60,7 +60,7 @@ function jsKalturaPlayerTest( videoId ){
 <body>
 <h2> SwfObject 2.2 embed test </h2>
 <b>Note:</b> SwfObject html5 library rewrite is deprecated, you should instead use <i>kWidget.embed</i>
-<div id="playbackModeSelector"></div>
+
 <br />
 <div id="videoPlayerTarget">
 </div><br>

--- a/modules/KalturaSupport/tests/EmptyPlayer.qunit.html
+++ b/modules/KalturaSupport/tests/EmptyPlayer.qunit.html
@@ -50,7 +50,7 @@ function jsKalturaPlayerTest( videoId ){
 </head>
 <body>
 <h2> Empty Player test </h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 <object id="kaltura_player" name="kaltura_player" type="application/x-shockwave-flash" allowFullScreen="true" 
 allowNetworking="all" allowScriptAccess="always" height="333" width="400" xmlns:dc="http://purl.org/dc/terms/" 

--- a/modules/KalturaSupport/tests/Flashembed.onPageLinks.qunit.html
+++ b/modules/KalturaSupport/tests/Flashembed.onPageLinks.qunit.html
@@ -62,7 +62,7 @@
 	<body>
 		<h2>Flashembed</h2>
 		<b>Note:</b> flashembed html5 library rewrite is deprecated, you should instead use <i>kWidget.embed</i>
-		<div id="playbackModeSelector"></div>
+		
 		
 		<!-- other parts of the page -->
 

--- a/modules/KalturaSupport/tests/FlashvarsReadyAtJsCallbackTime.qunit.html
+++ b/modules/KalturaSupport/tests/FlashvarsReadyAtJsCallbackTime.qunit.html
@@ -27,7 +27,7 @@ function jsKalturaPlayerTest( videoId ){
 </head>
 <body>
 <h2> Flashvars ready at js callback time test </h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 
 <object id="kaltura_player" name="kaltura_player" type="application/x-shockwave-flash" allowFullScreen="true" 

--- a/modules/KalturaSupport/tests/FlavorSelector.embedsizes.html
+++ b/modules/KalturaSupport/tests/FlavorSelector.embedsizes.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <h2> Flavor embed sizes test </h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 <div id="players"></div>
 <script>

--- a/modules/KalturaSupport/tests/FullscreenOnPlay.html
+++ b/modules/KalturaSupport/tests/FullscreenOnPlay.html
@@ -11,7 +11,7 @@
 <h2> Fullscreen on play </h2>
 This take the player into fullscreen mode with an event binded against doPlay. 
 When you pause the video it restores to window playback.
-<div id="playbackModeSelector"></div>
+
 <div id=kaltura_player style="width:400px;height:330px;"></div>
 <script>
 	kWidget.embed({

--- a/modules/KalturaSupport/tests/ImageEntryBumpers.html
+++ b/modules/KalturaSupport/tests/ImageEntryBumpers.html
@@ -28,7 +28,7 @@ function jsKalturaPlayerTest( videoId ){
 </head>
 <body>
 <h2> ImageEntry Bumpers test </h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 <object id="kaltura_player_1327618822" 
 	name="kaltura_player_1327618822" 

--- a/modules/KalturaSupport/tests/ImageEntryPlaylist.html
+++ b/modules/KalturaSupport/tests/ImageEntryPlaylist.html
@@ -21,7 +21,7 @@ function jsKalturaPlayerTest( videoId ){
 </head>
 <body>
 <h2> Image Entry Playlist test </h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 <object id="kaltura_player_1327276871" 
 	name="kaltura_player_1327276871" 

--- a/modules/KalturaSupport/tests/LegacyMultipleDynamicEmbeds.qunit.html
+++ b/modules/KalturaSupport/tests/LegacyMultipleDynamicEmbeds.qunit.html
@@ -42,7 +42,7 @@ function jsKalturaPlayerTest( videoId ){
 </head>
 <body>
 <h2> Legay Multiple Embeds test </h2>
-<div id="playbackModeSelector"></div>
+
 <br /><br />
 <a href="#" id="doEmbed">Do post domReady embed</a>
 <div id="videoContainer"></div>

--- a/modules/KalturaSupport/tests/LoadTimeTest.html
+++ b/modules/KalturaSupport/tests/LoadTimeTest.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <h2> Player load time test </h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 
 <div id="myPlayer" style="width:400px;height:330px;">

--- a/modules/KalturaSupport/tests/Loop.qunit.html
+++ b/modules/KalturaSupport/tests/Loop.qunit.html
@@ -45,7 +45,7 @@
 </head>
 <body>
 	<h2> Loop test for clips shorter than 10sec</h2>
-	<div id="playbackModeSelector"></div>
+	
 	<br />
 	<object id="kaltura_player" name="kaltura_player" type="application/x-shockwave-flash" 
 			allowFullScreen="true" allowNetworking="all" allowScriptAccess="always" height="333" width="400" 

--- a/modules/KalturaSupport/tests/MultipleAds.html
+++ b/modules/KalturaSupport/tests/MultipleAds.html
@@ -18,7 +18,7 @@
 	<li>02:38 - Postroll</li>
 </ul>
 
-<div id="playbackModeSelector"></div>
+
 <br /><br />
 
 <div id="myVideoTarget" style="width:400px;height:330px;"></div>

--- a/modules/KalturaSupport/tests/NoHLSforLessThan10Seconds.qunit.html
+++ b/modules/KalturaSupport/tests/NoHLSforLessThan10Seconds.qunit.html
@@ -53,7 +53,7 @@ mw.isIOS = function(){
 </head>
 <body>
 <h2> No HLS for Clips Less Than 10 Seconds test </h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 
 <object id="kaltura_player" name="kaltura_player" type="application/x-shockwave-flash" allowFullScreen="true" 

--- a/modules/KalturaSupport/tests/PPT_Widget.html
+++ b/modules/KalturaSupport/tests/PPT_Widget.html
@@ -13,7 +13,7 @@
   <body>
     <h1>
       PPT Widget
-    </h1><div id="playbackModeSelector"></div><br>
+    </h1><br>
     <br>
 	<div id="player_wrap">
 <object id="kaltura_player" name="kaltura_player" type="application/x-shockwave-flash" allowFullScreen="true" allowNetworking="all" allowScriptAccess="always" height="469" width="900" data="http://www.kaltura.com/index.php/kwidget/wid/_423851/uiconf_id/7598951/entry_id/1_85x12xpu">

--- a/modules/KalturaSupport/tests/PageTestDocumentZoom.html
+++ b/modules/KalturaSupport/tests/PageTestDocumentZoom.html
@@ -13,7 +13,7 @@
 </head>
 <body>
 <h2> Test Fullscreen on Page with Scrollbars</h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 <object id="kaltura_player" name="kaltura_player" 
 	type="application/x-shockwave-flash" 

--- a/modules/KalturaSupport/tests/PageWithVerticalScrollHideShow.html
+++ b/modules/KalturaSupport/tests/PageWithVerticalScrollHideShow.html
@@ -62,7 +62,7 @@ $( document ).ready(function(){
 });
 </script>
 <h2> Test Fullscreen on Page with Vertical Scroll Hide Show</h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 <a id="testHide" href="#">Test hide/show player</a> 
 <br />

--- a/modules/KalturaSupport/tests/PlayStopApi.qunit.html
+++ b/modules/KalturaSupport/tests/PlayStopApi.qunit.html
@@ -94,7 +94,7 @@ if( !window.QUnit ){
 	});
 }
 </script>
-<div id="playbackModeSelector"></div>
+
 <div id="kaltura_player_1360356455" style="width: 400px; height: 333px"></div>
 <script type="text/javascript">
 kWidget.embed({

--- a/modules/KalturaSupport/tests/PlayerEventsKdpReady.qunit.html
+++ b/modules/KalturaSupport/tests/PlayerEventsKdpReady.qunit.html
@@ -34,7 +34,7 @@ function onKdpReady( videoId ){
 </head>
 <body>
 <h2> Player Events KdpReady test </h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 
 <object id="kaltura_player" name="kaltura_player" type="application/x-shockwave-flash" allowFullScreen="true" 

--- a/modules/KalturaSupport/tests/PlayerSizeIOS.html
+++ b/modules/KalturaSupport/tests/PlayerSizeIOS.html
@@ -24,7 +24,7 @@ div, iframe, object { margin: 0; padding: 0; border: 0; }
 </head>
 <body>
 <h2>Player Size</h2>	
-<div id="playbackModeSelector"></div>
+
 <br />
 	<object id="kaltura_player" name="kaltura_player" type="application/x-shockwave-flash" allowFullScreen="true" 
 	allowNetworking="all" allowScriptAccess="always" height="333" width="400" xmlns:dc="http://purl.org/dc/terms/" 

--- a/modules/KalturaSupport/tests/PlaylistKalturaMRSS.html
+++ b/modules/KalturaSupport/tests/PlaylistKalturaMRSS.html
@@ -8,7 +8,7 @@
     </head>
    <body>
    	<h3>Playlist with Kaltura MRSS</h3>
-    <div id="playbackModeSelector"></div>
+    
    	<br> <br>
     <div id="kaltura_player_1367999865" style="width: 680px; height: 333px;"></div>
     <script>

--- a/modules/KalturaSupport/tests/PlaylistNewSkin.html
+++ b/modules/KalturaSupport/tests/PlaylistNewSkin.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <h2>Playlist New Skin</h2>	
-<div id="playbackModeSelector"></div>
+
 <br /><br />
 <object id="kaltura_player_1343044255" name="kaltura_player_1343044255" type="application/x-shockwave-flash" allowFullScreen="true" allowNetworking="all" allowScriptAccess="always" height="330" width="740" bgcolor="#000000" data="http://www.kaltura.com/index.php/kwidget/cache_st/1343044255/wid/_423851/uiconf_id/8714241">
 	<param name="allowFullScreen" value="true" />

--- a/modules/KalturaSupport/tests/PlaylistPlugins.html
+++ b/modules/KalturaSupport/tests/PlaylistPlugins.html
@@ -12,7 +12,7 @@
   <body>
 	<h1>Playlist Plugins</h1>
 	<h3>VAST (Preroll), Bumper(Nokia Ad), Captions plugin, Cue Points</h3>
-	<div id="playbackModeSelector"></div><br /><br />
+	<br /><br />
 	<object id="kaltura_player_1316950678" name="kaltura_player_1316950678" type="application/x-shockwave-flash" allowFullScreen="true" allowNetworking="all" allowScriptAccess="always" height="330" width="740" bgcolor="#000000" xmlns:dc="http://purl.org/dc/terms/" xmlns:media="http://search.yahoo.com/searchmonkey/media/" rel="media:video" resource="http://www.kaltura.com/index.php/kwidget/cache_st/1316950678/wid/_423851/uiconf_id/5843781" data="http://www.kaltura.com/index.php/kwidget/cache_st/1316950678/wid/_423851/uiconf_id/5843781">
 		<param name="allowFullScreen" value="true" />
 		<param name="allowNetworking" value="all" />

--- a/modules/KalturaSupport/tests/PlaylistPostRollBumper.html
+++ b/modules/KalturaSupport/tests/PlaylistPostRollBumper.html
@@ -39,7 +39,7 @@ function jsKalturaPlayerTest( videoId ){
 </head>
 <body>
 <h2> Playlist Postroll Bumper test </h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 <object id="kaltura_player_1328090850" 
 	name="kaltura_player_1328090850" 

--- a/modules/KalturaSupport/tests/PrototypeJsAndJQuery.qunit.html
+++ b/modules/KalturaSupport/tests/PrototypeJsAndJQuery.qunit.html
@@ -55,7 +55,7 @@ function jsKalturaPlayerTest( videoId ){
 </head>
 <body>
 <h2> Prototype js and jQuery integration test</h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 <object id="kaltura_player" name="kaltura_player" type="application/x-shockwave-flash" allowFullScreen="true" 
 allowNetworking="all" allowScriptAccess="always" height="333" width="400" xmlns:dc="http://purl.org/dc/terms/" 

--- a/modules/KalturaSupport/tests/ReadyCallback.html
+++ b/modules/KalturaSupport/tests/ReadyCallback.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <h2> ReadyCallback Test </h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 <div id="myVideoTarget" style="width:400px;height:257px;"></div>
 <script type="text/javascript">

--- a/modules/KalturaSupport/tests/ReplaceSources.qunit.html
+++ b/modules/KalturaSupport/tests/ReplaceSources.qunit.html
@@ -57,7 +57,7 @@ function jsKalturaPlayerTest( videoId ){
 </head>
 <body>
 <h2> Replace Flavors, Retain entry metadata </h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 
 <div id="myVideoTarget" style="width:400px;height:330px;">

--- a/modules/KalturaSupport/tests/SeekApi.qunit.html
+++ b/modules/KalturaSupport/tests/SeekApi.qunit.html
@@ -88,7 +88,7 @@ if( !window.QUnit ){
 	});
 }
 </script>
-<div id="playbackModeSelector"></div>
+
 <div id="kaltura_player_1360356455" style="width: 400px; height: 333px"></div>
 <script type="text/javascript">
 kWidget.embed({

--- a/modules/KalturaSupport/tests/SequenceEvents.html
+++ b/modules/KalturaSupport/tests/SequenceEvents.html
@@ -72,7 +72,7 @@ function jsKalturaPlayerTest( videoId ){
 </head>
 <body>
 <h2> Sequence Events test </h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 Show: <a id="adPlayer" href="#">Ad Player</a> | <a id="noAdPlayer" href="#">No Ad Player</a> 
 <br />

--- a/modules/KalturaSupport/tests/TallBasicPlayerLayout.html
+++ b/modules/KalturaSupport/tests/TallBasicPlayerLayout.html
@@ -49,7 +49,7 @@ function jsKalturaPlayerTest( videoId ){
 </head>
 <body>
 <h2> Tall Player Layout test </h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 <object id="kaltura_player" name="kaltura_player" type="application/x-shockwave-flash" allowFullScreen="true" 
 allowNetworking="all" allowScriptAccess="always" height="500" width="400" xmlns:dc="http://purl.org/dc/terms/" 

--- a/modules/KalturaSupport/tests/ThumbnailScrubber.html
+++ b/modules/KalturaSupport/tests/ThumbnailScrubber.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <h2> Access control - country restriction </h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 <div id="myVideoTarget" style="width:400px;height:330px;float:left">
 </div>

--- a/modules/KalturaSupport/tests/TitlePlaylist.qunit.html
+++ b/modules/KalturaSupport/tests/TitlePlaylist.qunit.html
@@ -55,7 +55,7 @@ function jsKalturaPlayerTest( videoId ){
 </head>
 <body>
 <h2> Title playlist test </h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 <object id="kaltura_player_1315358135"
  name="kaltura_player_1315358135" 

--- a/modules/KalturaSupport/tests/UseHLS_WhereAvailable.qunit.html
+++ b/modules/KalturaSupport/tests/UseHLS_WhereAvailable.qunit.html
@@ -53,7 +53,7 @@ mw.isIOS = function(){
 </head>
 <body>
 <h2> Use HLS Where Available test ( including android ) </h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 <div id="kaltura_player" style="width:400px;height:333px;"></div>
 <script>

--- a/modules/KalturaSupport/tests/https.html
+++ b/modules/KalturaSupport/tests/https.html
@@ -8,7 +8,7 @@
   <body>
     <h1>
       HTTPs Player
-    </h1><div id="playbackModeSelector"></div><br>
+    </h1><br>
     <br>
 
 <script type="text/javascript" src="../../../mwEmbedLoader.php"></script>

--- a/modules/KalturaSupport/tests/iPadHTML_Controls_Native_EnableIpadNativeFullscreen.html
+++ b/modules/KalturaSupport/tests/iPadHTML_Controls_Native_EnableIpadNativeFullscreen.html
@@ -13,7 +13,7 @@
 </head>
 <body>
 <h2> iPad HTML5 controls native fullscreen controls</h2>
-<div id="playbackModeSelector"></div>
+
 <b>NOTE the native fullscreen button only works during playback</b> ( device restriction )
 <pre class="prettyprint linenums">
 // Set a player flag to enable native fullscreen

--- a/modules/KalturaSupport/tests/iPhoneDisableShowHTMLPlayScreen.html
+++ b/modules/KalturaSupport/tests/iPhoneDisableShowHTMLPlayScreen.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <h2> iPhone show html5 player test </h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 
 <object id="kaltura_player" name="kaltura_player" type="application/x-shockwave-flash" allowFullScreen="true" 

--- a/modules/KalturaSupport/tests/jQuery1.2_NoApi_Integration.html
+++ b/modules/KalturaSupport/tests/jQuery1.2_NoApi_Integration.html
@@ -9,7 +9,7 @@
 </head>
 <body>
 <h2> jQuery 1.2 NOAPI Integration </h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 <object id="kaltura_player" name="kaltura_player" 
 	type="application/x-shockwave-flash" 

--- a/modules/KalturaSupport/tests/jQuery1.3.2_Integration.html
+++ b/modules/KalturaSupport/tests/jQuery1.3.2_Integration.html
@@ -9,7 +9,7 @@
 </head>
 <body>
 <h2> jQuery 1.3.2 Integration </h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 <object id="kaltura_player" name="kaltura_player" 
 	type="application/x-shockwave-flash" 

--- a/modules/KalturaSupport/tests/kBind_kUnbind.qunit.html
+++ b/modules/KalturaSupport/tests/kBind_kUnbind.qunit.html
@@ -205,7 +205,7 @@ kWidget.addReadyCallback( function( playerId ){
 	</pre>
 	
 	<br />
-	<div id="playbackModeSelector"></div>
+	
 	<div id="myVideoTarget" style="width: 400px; height: 330px"></div>
 	<script>
 		kWidget.embed({

--- a/modules/KalturaSupport/tests/kWidget.embed.dynamicInjectOfMwEmbed.html
+++ b/modules/KalturaSupport/tests/kWidget.embed.dynamicInjectOfMwEmbed.html
@@ -5,7 +5,7 @@
 </head>
 <body>
 <h2> kWidget Dynamic Player Embed </h2>
-<div id="playbackModeSelector"></div>
+
 <br /><br />
 <a id="doIncludeLib" href="#">Include mwEmbed, then run kWidget.embed</a> </br>
 <div id="myVideoTarget" style="width:400px;height:330px;">

--- a/modules/KalturaSupport/tests/kWidget.embed.emptyPlayer.qunit.html
+++ b/modules/KalturaSupport/tests/kWidget.embed.emptyPlayer.qunit.html
@@ -42,7 +42,7 @@ function jsKalturaPlayerTest( videoId ){
 </head>
 <body>
 <h2> kWidget Empty Player test </h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 
 <div id="myVideoTarget" style="width:400px;height:330px;">

--- a/modules/KalturaSupport/tests/kWidget.embed.withOnPageObjects.qunit.html
+++ b/modules/KalturaSupport/tests/kWidget.embed.withOnPageObjects.qunit.html
@@ -36,7 +36,7 @@ function readyCallbackFired( playerId ){
 </head>
 <body>
 <h2> kWidget with Object tag on page test </h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 
 <div id="myVideoTarget" style="width:400px;height:330px;">

--- a/modules/KalturaSupport/tests/kWidget.embedParams.qunit.html
+++ b/modules/KalturaSupport/tests/kWidget.embedParams.qunit.html
@@ -31,7 +31,7 @@ function jsKalturaPlayerTest( videoId ){
 </head>
 <body>
 <h2> Flash embed params </h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 Kwidget.embed supports the param option to pass parmas to the flash embed. 
 <pre class="prettyprint linenums">

--- a/modules/KalturaSupport/tests/liveThumbnails.html
+++ b/modules/KalturaSupport/tests/liveThumbnails.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <h2>Live Thumbnails over scrubber</h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 <div id="myVideoTarget" style="width:400px;height:330px;float:left">
 </div>

--- a/modules/KalturaSupport/tests/playerSizes.html
+++ b/modules/KalturaSupport/tests/playerSizes.html
@@ -27,7 +27,7 @@ function jsKalturaPlayerTest( videoId ){
 </head>
 <body>
 <h2>Player Sizes test </h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 
 Small basic controls <br>

--- a/modules/KalturaSupport/tests/showAlert.html
+++ b/modules/KalturaSupport/tests/showAlert.html
@@ -76,7 +76,7 @@ $( '#displayAlert_b' ).click(function(){
 });
 	</pre>
 	<br />
-	<div id="playbackModeSelector"></div>
+	
 	<div id="kaltura_player" style="width:400px;height:330px;"></div>
 	<script>
 	kWidget.embed({

--- a/modules/KalturaSupport/tests/silverlight.html
+++ b/modules/KalturaSupport/tests/silverlight.html
@@ -14,7 +14,7 @@
 mw.setConfig("EmbedPlayer.ForceSPlayer" , true) ;
 
 </script>
-<div id="playbackModeSelector"></div>
+
 <div id="kaltura_player_1360356455" style="width: 400px; height: 333px"></div>
 <script type="text/javascript">
     kWidget.embed({

--- a/modules/NielsenCombined/tests/IntegrationVastNielsen.html
+++ b/modules/NielsenCombined/tests/IntegrationVastNielsen.html
@@ -40,7 +40,7 @@ function jsKalturaPlayerTest( videoId ){
 </head>
 <body>
 <h2> Integration Vast Nielsen test</h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 <object id="kaltura_player" name="kaltura_player" type="application/x-shockwave-flash" allowFullScreen="true" 
 allowNetworking="all" allowScriptAccess="always" height="333" width="400" xmlns:dc="http://purl.org/dc/terms/" 

--- a/modules/Omniture/tests/siteCatalyst15Playlist.html
+++ b/modules/Omniture/tests/siteCatalyst15Playlist.html
@@ -26,7 +26,7 @@ function jsKalturaPlayerTest( videoId ){
 </head>
 <body>
 <h2> Omniture siteCatalyst15 playlist test </h2>
-<div id="playbackModeSelector"></div>
+
 <br />
 
 <div id="kaltura_player" style="width:740px;height:330px"></div>


### PR DESCRIPTION
removed the player chooser we only really support v2 now days. 

Old test files that are flash specific retain the disablePlaybackModeSelector flag, and use flash by default. 
