### PR TITLE
{utility.random} should evaluate to an int

### DIFF
--- a/modules/KalturaSupport/resources/mw.KDPMapping.js
+++ b/modules/KalturaSupport/resources/mw.KDPMapping.js
@@ -479,7 +479,7 @@
 				case 'utility':
 					switch( objectPath[1] ) {
 						case 'random':
-							return Math.random();
+							return Math.floor(Math.random() * 1000000000);
 							break;
 						case 'timestamp':
 							return new Date().getTime();


### PR DESCRIPTION
Kalturions:

For your consideration - The newly minted {utility.random}, which (enables _proxied_ VAST endpoints to contain cache-busting timestamps/random numbers which are interpolated before each video is played) currently returns a float - this results in at least one ad network returning an empty VAST response. Changing this to an int remedies the situation for us.

I've opened a support issue containing the specifics of this issue as it pertains to our current project. The ticket number is #00046265. Please feel free to contact me there with client-specific questions or here with general concerns or questions.

Thanks in advance!
