### PR TITLE
FEC-1611 #comment Add error callback for script load failure #time 0.5d

### DIFF
--- a/kWidget/kWidget.js
+++ b/kWidget/kWidget.js
@@ -1874,10 +1874,11 @@ var kWidget = {
 	/**
 	 * Append a script to the dom:
 	 * @param {string} url
-	 * @param {function} callback
+	 * @param {function} done callback
 	 * @param {object} Document to append the script on
+	 * @param {function} error callback
 	 */
-	appendScriptUrl: function( url, callback, docContext ) {
+	appendScriptUrl: function( url, callback, docContext, callbackError ) {
 		if( ! docContext ){
 			docContext = window.document;
 		}
@@ -1888,16 +1889,31 @@ var kWidget = {
 		var done = false;
 
 		// Attach handlers for all browsers
-		script.onload = script.onreadystatechange = function() {
+		script.onload = script.onerror = script.onreadystatechange = function() {
 			if ( !done && (!this.readyState ||
 					this.readyState === "loaded" || this.readyState === "complete") ) {
 				done = true;
-				if( typeof callback == 'function'){
-					callback();
+
+				if (arguments &&
+					arguments[0] &&
+					arguments[0].type){
+					if (arguments[0].type == "error"){
+						if (typeof callbackError == "function"){
+							callbackError();
+						}
+					} else {
+						if (typeof callback == "function"){
+							callback();
+						}
+					}
+				} else {
+					if (typeof callback == "function"){
+						callback();
+					}
 				}
 
 				// Handle memory leak in IE
-				script.onload = script.onreadystatechange = null;
+				script.onload = script.onerror = script.onreadystatechange = null;
 				if ( head && script.parentNode ) {
 					head.removeChild( script );
 				}

--- a/modules/Tremor/resources/mw.Tremor.js
+++ b/modules/Tremor/resources/mw.Tremor.js
@@ -50,7 +50,7 @@ mw.Tremor.prototype = {
 			kWidget.appendScriptUrl( _this.getAdManagerUrl(), function(){
 				_this.setupAds();
 				callback();
-			}, document );
+			}, document, callback );
 		} else{
 			_this.setupAds();
 			callback();


### PR DESCRIPTION
- Enable error callback for script load failure.
- Register tremor init callback failure in order to prevent player from
  hanging in infinite loading state.
