### PR TITLE
#SUP-2434

### DIFF
--- a/modules/KalturaSupport/resources/uiConfComponents/playbackRateSelector.js
+++ b/modules/KalturaSupport/resources/uiConfComponents/playbackRateSelector.js
@@ -23,7 +23,7 @@
 				deferred = $.Deferred();
 
 			this.bind('playerReady', function(){
-				deferred.resolve(!!_this.getPlayer().playbackRate);
+				deferred.resolve(!!_this.getPlayer().getPlayerElement().playbackRate);
 			});
 			return deferred.promise();
 		},


### PR DESCRIPTION
fixed deferred condition to look for the playbackRate in the player element instead of the player (in the player it is always false but returns true on all browsers but Firefox)
