### PR TITLE
Update mediawiki.client.js

### DIFF
--- a/modules/MwEmbedSupport/mediawiki/mediawiki.client.js
+++ b/modules/MwEmbedSupport/mediawiki/mediawiki.client.js
@@ -45,6 +45,12 @@
 	mw.isIpad3 = function(){
 		return  /OS 3_/.test( userAgent ) && mw.isIpad();
 	};
+	mw.isAndroid44 = function(){
+		return ( userAgent.indexOf( 'Android 4.2') != -1 );
+	};
+	mw.isAndroid43 = function(){
+		return ( userAgent.indexOf( 'Android 4.2') != -1 );
+	};
 	mw.isAndroid42 = function(){
 		return ( userAgent.indexOf( 'Android 4.2') != -1 );
 	};
@@ -93,6 +99,9 @@
 
 	mw.isIOS7 = function(){
 		return /OS 7_/.test( userAgent ) && mw.isIOS();
+	};
+	mw.isIOS8 = function(){
+		return /OS 8_/.test( userAgent ) && mw.isIOS();
 	};
 
 	// Does the client has native touch bindings?


### PR DESCRIPTION
Support for android 4.3, 4.4 and support for ios 8.
