### PR TITLE
FEC-1730 #comment Add timed check for adsManager #time 1d

### DIFF
--- a/modules/DoubleClick/DoubleClick.manifest.php
+++ b/modules/DoubleClick/DoubleClick.manifest.php
@@ -61,7 +61,13 @@ return array (
 				'doc' => "Determine the order DoubleClick should occupy among other pre sequence plugins. Set to zero to disable preroll. ( This has no effect in managed ad player.)",
 				'initvalue' => 1,
 				'type' => 'number',
-			)
+			),
+            'adsManagerLoadedTimeout'=> array(
+                'label' => 'Pre sequence index',
+                'doc' => "Timer for timed checking if adsManager was loaded(in milliseconds)",
+                'initvalue' => 5000,
+                'type' => 'number',
+            )
 		)
 	)
 );


### PR DESCRIPTION
Add configurable timed check var to double-click for verifying that
adsManager was actually loaded.
ima3 is blocked when to adBlockPlus in a manner that halts the
adsManager form being loaded correctly!
