### PR TITLE
#FEC-1773 #comment fix silverlight on IE #time 1h

### DIFF
--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerSilverlight.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerSilverlight.js
@@ -48,10 +48,6 @@
 			);
 
 			this.loadMedia( readyCallback );
-
-			//hide player until we click play
-			this.getPlayerContainer().css('visibility', 'hidden');
-
 		},
 
 		loadMedia: function( readyCallback ) {
@@ -314,6 +310,8 @@
 		onDurationChange: function( data, id ) {
 			//first durationChange indicate player is ready
 			if ( !this.durationReceived ) {
+				//hide player until we click play
+				this.getPlayerContainer().css('visibility', 'hidden');
 				this.durationReceived = true;
 				if ( !this.isError ) {
 					this.callReadyFunc();


### PR DESCRIPTION
If the player is hidden the silverlight player is not loading, probably due to IE optimisation. So we are "hiding" the player after the media was loaded into silverlight
