### PR TITLE
FEC-1736 #comment Fix wrong access to mediaProxy params #time 0.5d

### DIFF
--- a/modules/KalturaSupport/resources/uiConfComponents/segmentScrubberPlugin.js
+++ b/modules/KalturaSupport/resources/uiConfComponents/segmentScrubberPlugin.js
@@ -19,8 +19,8 @@
 		updateTimeOffsets: function(){
 			var player = this.getPlayer();
 			var stopEvent = 'doStop.segmentScrubber';
-			var timeIn = player.getKalturaConfig('mediaProxy', 'mediaPlayFrom' );
-			var timeOut = player.getKalturaConfig('mediaProxy', 'mediaPlayTo' );
+			var timeIn = player.startTime;
+			var timeOut = player.pauseTime;
 			player.startTime = timeIn;
 			player.startOffset = timeIn;
 			player.setDuration( timeOut - timeIn );


### PR DESCRIPTION
Initial values of mediaProxy are set as full strings in config, e.g.
mediaProxy.mediaPlayFrom is set as key: mediaProxy.mediaPlayFrom, while
the setKdpAttribute saves the values as compound object, e.g.
mediaProxy:{mediaPlayFrom: someValueHere}.
In general we need to align this to be same for all input output
scenarios.
