### PR TITLE
FEC-1856 #comment Remove ref to Silverlight current time #time 4h

### DIFF
--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerSilverlight.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerSilverlight.js
@@ -273,7 +273,6 @@
 		updatePlayhead: function () {
 			if ( this.seeking ) {
 				this.seeking = false;
-				this.slCurrentTime = this.playerObject.currentTime;
 			}
 		},
 


### PR DESCRIPTION
Removed reference to silverlight element current time, as it is not
being used when embedPlayer is bounded to it, and it return undefined.
When embedPlayer is the bounded object then the currentTime is updated
via “onUpdatePlayhead” function.
