### PR TITLE
FEC-1866 #comment Fix freezing after initial seek #time 1.5d

### DIFF
--- a/modules/KalturaSupport/components/currentTimeLabel.js
+++ b/modules/KalturaSupport/components/currentTimeLabel.js
@@ -49,7 +49,7 @@
 			this.getComponent().text( mw.seconds2npt( time ) );
 		},
 		getCurrentTime: function(){
-			var ct = this.getPlayer().currentTime - this.getPlayer().startOffset;
+			var ct = this.getPlayer().getPlayerElementTime() - this.getPlayer().startOffset;
 			if( ct < 0 ){
 				ct = 0;
 			}


### PR DESCRIPTION
Fix issue where seeking before first play would result in hanging
player with spinner.
We should refactor the code to accommodate the common handling of seek
logic for Native/KPlayer/SLPlayer - as they share a lot of logic, but
currently it isn’y possible to refactor due to Native player code
complexity.
