### PR TITLE
FEC-1898

### DIFF
--- a/modules/ExternalPlayers/resources/mw.EmbedPlayerYouTube.js
+++ b/modules/ExternalPlayers/resources/mw.EmbedPlayerYouTube.js
@@ -159,6 +159,10 @@
 				if (mw.isMobileDevice()){
 					$(".largePlayBtn").hide();
 					$(".mwEmbedPlayer").hide();
+					_this.hideSpinner();
+					setTimeout(function(){ // issue another hideSpinner call after 250 ms for slow devices (FEC-1898)
+						_this.hideSpinner();
+					},250);
 				}
 
 			};


### PR DESCRIPTION
hide loading spinner on mobile devices on first load in order to prevent showing spinner misalignment. The misalignment is caused due to the resize $(".mwEmbedPlayer") that must be done in order to expose the red play button.
