### PR TITLE
SUP-2689

### DIFF
--- a/modules/DoubleClick/resources/mw.DoubleClick.js
+++ b/modules/DoubleClick/resources/mw.DoubleClick.js
@@ -630,6 +630,7 @@
 				if ( ad.a ) {
 					_this.isLinear = ad.a.linear;
 				}
+				$("#adContainervideoTarget").show();
 				// dispatch adOpen event
 				$( _this.embedPlayer).trigger( 'onAdOpen',[ad.a.adId, ad.a.adSystem, _this.currentAdSlotType, ad.a.adPodInfo ? ad.a.adPodInfo.adPosition : 0] );
 
@@ -995,7 +996,14 @@
 			var _this = this;
 			this.adActive = false;
 			if (this.isChromeless){
+				if (_this.isLinear){
+					$(".mwEmbedPlayer").show();
+				}
 				this.embedPlayer.getPlayerElement().redrawObject(50);
+			}else{
+				if (_this.isLinear){
+					$("#adContainervideoTarget").hide();
+				}
 			}
 			this.embedPlayer.sequenceProxy.isInSequence = false;
 


### PR DESCRIPTION
make sure the video cover layer is hidden during ad playback and shown during video playback in both JS and Flash implementations. Known limitation: video click for play/pause will not work during overlay ad playback (in order to support the ad clickthrough)
