### PR TITLE
fixed ks initialization when ks is not generated by php or passed with flashvars

### DIFF
--- a/modules/KalturaSupport/resources/mw.KApi.js
+++ b/modules/KalturaSupport/resources/mw.KApi.js
@@ -124,7 +124,7 @@ mw.KApi.prototype = {
 		// Add the Kaltura session ( if not already set )
 		var ksParam = {
 				'action' : 'startwidgetsession',
-				'widgetId': '_' + this.widget_id
+				'widgetId': this.widgetId
 		};
 		// add in the base parameters:
 		var param = $.extend( { 'service' : 'session' }, this.baseParam, ksParam );


### PR DESCRIPTION
- there was a typo in the parameter name
- underscore is not required because the widget id already contains the underscone
