### PR TITLE
#FEC-320 return an empty string where node.childNodes is zero

### DIFF
--- a/modules/TimedText/resources/mw.TextSource.js
+++ b/modules/TimedText/resources/mw.TextSource.js
@@ -360,6 +360,8 @@
 				nodeString += '</' + node.nodeName + '>';
 				return nodeString;
 			}
+			// be sure to return an empty string where node.childNodes is empty
+			return '';
 		},
 		/**
 		 * srt timed text parse handle:


### PR DESCRIPTION
fixes issue #733 by ensuring it always returns an empty string.   
