### PR TITLE
FEC-2045 #comment Trigger onAdSkip event before skip #time 4h

### DIFF
--- a/modules/KalturaSupport/resources/mw.KAdPlayer.js
+++ b/modules/KalturaSupport/resources/mw.KAdPlayer.js
@@ -925,9 +925,6 @@ mw.KAdPlayer.prototype = {
 		$( _this.embedPlayer ).bind( 'onChangeMedia' + this.displayPostFix, function(){
 			adSlot.playbackDone();
 		});
-		$( _this.embedPlayer ).bind( 'ended' + this.displayPostFix, function(){
-			adSlot.playbackDone();
-		});
 
 		// Only display the the overlay for allocated time:
 		adSlot.doneFunctions.push(function(){


### PR DESCRIPTION
Trigger onAdSkip before preforming skip in order to allow listeners to
be triggered before the actual skip action removed the bindings
