### PR TITLE
FEC-2092 #comment Fix ignoreNextNativeEvent lock on iOS8 #time 1d

### DIFF
--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
@@ -861,6 +861,7 @@ mw.EmbedPlayerNative = {
 					// Restore
 					vid.controls = originalControlsState;
 					_this.ignoreNextError = false;
+					_this.ignoreNextNativeEvent = false;
 					// check if we have a switch callback and issue it now:
 					if ( $.isFunction( switchCallback ) ){
 						mw.log("EmbedPlayerNative:: playerSwitchSource> call switchCallback");


### PR DESCRIPTION
In iOS7 due to crashing on ads and related plugins we introduced a new source switching technic where we changed the source tag under the video element instead of the actual src attribute on the video element itself.
Later on in the flow we called out native player play function that in turn checks if current src attribute on video element is the correct video source \URL and if not it changes it.

This is different between iOS7 and iOS8 due to the above flow and the additional source change in iOS7 causes a series of events the eventually unfreeze the _ignoreNextNativeEvent_ flag.
Because this is redundant in iOS8 (related and ads plugins work OK) then the additional source switching doesn't occur and _ignoreNextNativeEvent_ flag doesn't get unlocked and prevent player events propagation (mainly the _onpause event handler) which causes the player hanging issue.
