### PR TITLE
fix incorrect domain for comscore using http

### DIFF
--- a/modules/Comscore/resources/mw.Comscore.js
+++ b/modules/Comscore/resources/mw.Comscore.js
@@ -288,7 +288,7 @@ mw.Comscore.prototype = {
 	comScoreBeacon: function( beaconObject ) {
 		var _this = this;
 
-		var loadUrl = (document.location.protocol == "https:" ? "https://sb." : "http://b");
+		var loadUrl = (document.location.protocol == "https:" ? "https://sb." : "http://b.");
 		loadUrl += "scorecardresearch.com/p?";
 
 		// Setup C7 - Page URL Param


### PR DESCRIPTION
The comscore plugin, when using http instead of https, makes calls to 'bscorecardresearch.com', not 'b.scorecardresearch.com' as it should.
