### PR TITLE
FEC-2146

### DIFF
--- a/modules/DoubleClick/resources/mw.DoubleClick.js
+++ b/modules/DoubleClick/resources/mw.DoubleClick.js
@@ -803,7 +803,9 @@
 			},'displayCompanion', true);
 
 			this.embedPlayer.getPlayerElement().subscribe(function(adInfo){
-				_this.restorePlayer(true);
+				setTimeout(function(){
+					_this.restorePlayer(true);
+				},0);
 				if (_this.currentAdSlotType == 'postroll'){
 					_this.embedPlayer.triggerHelper( 'AdSupport_AdUpdateDuration', _this.entryDuration );
 					_this.embedPlayer.triggerHelper( 'timeupdate', 0);


### PR DESCRIPTION
execute restorePlayer on allAdsComplete event using a 0 seconds timeout to allow the previous restorePlayer (triggered by adComplete event) to finish
