### PR TITLE
#time 7h #comment prevent redundant switchCallBack on iPAD

### DIFF
--- a/modules/EmbedPlayer/resources/mw.EmbedPlayer.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayer.js
@@ -1630,7 +1630,7 @@
 					}
 				};
 
-				if( $.isFunction(_this.changeMediaCallback) ){
+				if( $.isFunction(_this.changeMediaCallback) && !mw.isIpad()){
 					setTimeout(function(){
 						_this.changeMediaCallback( changeMediaDoneCallback );
 					},250);


### PR DESCRIPTION
prevent duplicated play event causing the entry to play before preroll starts.
The entire changeMediaCallback should be investigated as it seems redundant when using native player.
