### PR TITLE
Fec 2163

### DIFF
--- a/modules/KalturaSupport/components/playlistAPI.js
+++ b/modules/KalturaSupport/components/playlistAPI.js
@@ -231,7 +231,7 @@
 				mw.log( 'mw.PlaylistAPI:: onChangeMediaDone' );
 				embedPlayer.triggerHelper( eventToTrigger );
 				_this.loadingEntry = false; // Update the loadingEntry flag//
-				// play clip that was selected event if autoPlay=false
+				// play clip that was selected when autoPlay=false. if autoPlay=true, the embedPlayer will do that for us.
 				if (!_this.getConfig("autoPlay")){
 					embedPlayer.play();
 				}


### PR DESCRIPTION
check for the same entry id at the begining of the playMedia function.

 Also added a fix to play each selected clip event if autoPlay=false (caused by fixed autoPlay logic commit)
