### PR TITLE
PS-1861

### DIFF
--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
@@ -179,6 +179,9 @@ mw.EmbedPlayerNative = {
 				_this.pause();
 				_this.updatePosterHTML();
 			}
+			if ( !(mw.isIOS7() && mw.isIphone())){
+				_this.changeMediaCallback = null;
+			}
 			callback();
 		});
 	},
@@ -832,7 +835,7 @@ mw.EmbedPlayerNative = {
 				// empty out any existing sources:
 				$( vid ).empty();
 
-				if ( mw.isIOS7() ){
+				if ( mw.isIOS7() && mw.isIphone()){
 					vid.src = null;
 					var sourceTag = document.createElement('source');
 					sourceTag.setAttribute('src', src);


### PR DESCRIPTION
prevent running playerSwitchSource as a callback. Limitation - must run playerSwitchSource on iPhone iOS7 to prevent crash so this fix doesn't apply to iPhone with iOS7. Will continue investigate.
Also, prevent reloading the current movie when switching media unless on iPhone and iOS7.
