### PR TITLE
Support seek after pre sequence

### DIFF
--- a/modules/AdSupport/resources/mw.AdTimeline.js
+++ b/modules/AdSupport/resources/mw.AdTimeline.js
@@ -103,6 +103,7 @@
 		firstPlay: true,
 
 		bindPostfix: '.AdTimeline',
+		pendingSeek: false,
 
 		currentAdSlotType: null,
 
@@ -168,6 +169,17 @@
 
 				// Start of preSequence
 				embedPlayer.triggerHelper( 'AdSupport_PreSequence');
+
+				mw.log( 'EmbedPlayer::preSeek : prevented seek during ad playback');
+				embedPlayer.unbindHelper("preSeek" + _this.bindPostfix).bindHelper("preSeek" + _this.bindPostfix, function(e, percentage, stopAfterSeek, stopSeek) {
+					embedPlayer.unbindHelper( "preSeek" + _this.bindPostfix );
+					stopSeek.value = true;
+					_this.pendingSeek = true;
+					_this.pendingSeekData = {
+						percentage: percentage,
+						stopAfterSeek: stopAfterSeek
+					};
+				});
 
 				//Setup a playedAnAdFlag
 				var playedAnAdFlag = false;
@@ -433,6 +445,12 @@
 				return;
 			}
 			embedPlayer.restoreEventPropagation();
+
+			if (this.pendingSeek){
+				this.pendingSeek = false;
+				embedPlayer.seek(this.pendingSeekData.percentage, this.pendingSeekData.stopAfterSeek);
+			}
+
 			embedPlayer.enablePlayControls();
 			embedPlayer.seeking = false;
 			// restore in sequence property;

--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerKplayer.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerKplayer.js
@@ -440,6 +440,14 @@ mw.EmbedPlayerKplayer = {
 				return;
 			}
 		}
+
+		// Trigger preSeek event for plugins that want to store pre seek conditions.
+		var stopSeek = {value: false};
+		this.triggerHelper( 'preSeek', [percentage, stopAfterSeek, stopSeek] );
+		if(stopSeek.value){
+			return;
+		}
+
 		this.seeking = true;
 
 		// Save currentTime
@@ -459,7 +467,6 @@ mw.EmbedPlayerKplayer = {
 			if( stopAfterSeek ){
 				_this.hideSpinner();
 				_this.pause();
-//				_this.stopMonitor();
 				_this.updatePlayheadStatus();
 			} else {
 				// continue to playback ( in a non-blocking call to avoid synchronous pause event )

--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
@@ -392,10 +392,6 @@ mw.EmbedPlayerNative = {
 	*/
 	seek: function( percent, stopAfterSeek ) {
 		var _this = this;
-		if (this.sequenceProxy && this.sequenceProxy.isInSequence){
-			mw.log( 'EmbedPlayerNative::seek : prevented seek during ad playback');
-			return;
-		}
 		// bounds check
 		if( percent < 0 ){
 			percent = 0;
@@ -410,7 +406,11 @@ mw.EmbedPlayerNative = {
 		this.kPreSeekTime = _this.currentTime;
 
 		// Trigger preSeek event for plugins that want to store pre seek conditions.
-		this.triggerHelper( 'preSeek', percent );
+		var stopSeek = {value: false};
+		this.triggerHelper( 'preSeek', [percent, stopAfterSeek, stopSeek] );
+		if(stopSeek.value){
+			return;
+		}
 
 		this.seeking = true;
 		// Update the current time ( local property )

--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerSilverlight.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerSilverlight.js
@@ -463,6 +463,13 @@
 
 				// Save currentTime
 				this.kPreSeekTime = _this.currentTime;
+				// Trigger preSeek event for plugins that want to store pre seek conditions.
+				var stopSeek = {value: false};
+				this.triggerHelper( 'preSeek', [percentage, stopAfterSeek, stopSeek] );
+				if(stopSeek.value){
+					return;
+				}
+
 				this.currentTime = ( percentage * this.duration ).toFixed( 2 ) ;
 
 				// trigger the html5 event:


### PR DESCRIPTION
If entry contains pre sequence then on seek first play pre sequence and
afterwards perform seek.
If entry also contains a mid roll and initial seek causes it to be
triggered then the flow will be pre sequence, then seek, then mid roll
and only then entry will play from target seek point.
