### PR TITLE
Fix seek after pre-sequence

### DIFF
--- a/modules/AdSupport/resources/mw.AdTimeline.js
+++ b/modules/AdSupport/resources/mw.AdTimeline.js
@@ -449,6 +449,9 @@
 			if (this.pendingSeek){
 				this.pendingSeek = false;
 				embedPlayer.seek(this.pendingSeekData.percentage, this.pendingSeekData.stopAfterSeek);
+			} else {
+				//If seek wasn't performed then and ad sequence is over then remove the seek handler
+				embedPlayer.unbindHelper( "preSeek" + this.bindPostfix );
 			}
 
 			embedPlayer.enablePlayControls();


### PR DESCRIPTION
Seek handler during ad pre-sequence needs to be unbind if no seek was
performed, otherwise first seek doesn’t work.
