### PR TITLE
#FEC-2195

### DIFF
--- a/resources/mediawiki/mediawiki.kmenu.js
+++ b/resources/mediawiki/mediawiki.kmenu.js
@@ -102,6 +102,7 @@
         open: function(){
         	var _this = this;
         	this.$el.addClass('open');
+	        $(".ui-tooltip").hide();
         	// Bind to click event and close the menu
             if( this.options.closeOnFocusOut ) {
                 setTimeout(function(){


### PR DESCRIPTION
hide tooltip when kMenu is clicked (works on all plugins with menu)
