### PR TITLE
TOG-125 #comment Prevent force ending clip #time 4h

### DIFF
--- a/modules/EmbedPlayer/resources/mw.EmbedPlayer.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayer.js
@@ -2631,7 +2631,9 @@
 						mw.log( "EmbedPlayer::updatePlayheadStatus > should run clip done :: " + this.currentTime + ' > ' + endPresentationTime );
 						_this.onClipDone();
 						//sometimes we don't get the "end" event from the player so we trigger clipdone
-					} else if ( !this.shouldEndClip && ( ( ( this.currentTime - this.startOffset) / endPresentationTime ) >= .99 ) ){
+					} else if ( !this.shouldEndClip &&
+						!this.isInSequence() &&
+						( ( ( this.currentTime - this.startOffset) / endPresentationTime ) >= .99 ) ){
 						_this.shouldEndClip = true;
 						setTimeout( function() {
 							if ( _this.shouldEndClip ) {


### PR DESCRIPTION
If midroll is set very close to end of entry (if precision is necessary
then if midriff start time is set to be greater or equal to 0.99% of
entry duration :-)) then after a predefined amount of time the player
forces clip done - this is to protect against cases (android) where
video doesn’t trigger ended event.
The above is not good for midriff cases, but only for actual entry
playback so added a check to not force clip done if we are in sequence.
