### PR TITLE
demo of tooltip read aloud and voice controls via chrome voice API

### DIFF
--- a/modules/KalturaSupport/KalturaSupport.php
+++ b/modules/KalturaSupport/KalturaSupport.php
@@ -86,6 +86,11 @@
 		/** 
 		 * Layout Components 
 		 **/
+        "aria" => array(
+            'scripts' => "components/aria/aria.js",
+            'dependencies' => 'mw.KBaseComponent',
+            'kalturaPluginName' => 'aria',
+        ),
 		"theme" => array(
 			'scripts' => "components/theme.js",
 			'dependencies' => 'mw.KBaseComponent',

--- a/modules/KalturaSupport/components/aria/aria.js
+++ b/modules/KalturaSupport/components/aria/aria.js
@@ -1,0 +1,90 @@
+(function (mw, $) {
+	"use strict";
+
+	mw.PluginManager.add('aria', mw.KBaseComponent.extend({
+
+		defaultConfig: {
+			'readTooltips': true,
+			'locale': 'en',
+			'voiceCommands': false
+		},
+
+		sound: null,
+
+		setup: function (embedPlayer) {
+			if (mw.isIE8()) {
+				mw.log("aria::aria plugin not supported in IE8");
+				return;
+			}
+			this.sound = new Audio();
+			this.addBindings();
+			if (this.getConfig("voiceCommands")) {
+				this.setupVoiceCommands()
+			}
+		},
+
+		addBindings: function () {
+			var _this = this;
+			if (this.getConfig("readTooltips")) {
+				this.bind('playerReady', function (event) {
+					var buttonsArr = _this.embedPlayer.getInterface().find(".btn");
+					for (var i = 0; i < buttonsArr.length; i++) {
+						$(buttonsArr[i]).on("mouseenter", function (e) {
+							if (!!$(this).attr("title")) {
+								_this.sound.src = kWidget.getPath() + "/modules/KalturaSupport/components/aria/tts.php?tl=" + _this.getConfig('locale') + "&q=" + $(this).attr("title");
+								_this.sound.play();
+							}
+						})
+					}
+				});
+			}
+		},
+
+		setupVoiceCommands: function () {
+			var _this = this;
+			if (!('webkitSpeechRecognition' in window)) {
+				mw.log("aria::Voice commands are supported only in Google Chrome");
+				return;
+			}
+			var recognition = new webkitSpeechRecognition();
+			recognition.continuous = true;
+			recognition.interimResults = false;
+			recognition.lang = "en";
+			recognition.start();
+			recognition.onresult = function (event) {
+				for (var i = event.resultIndex; i < event.results.length; ++i) {
+					if (event.results[i].isFinal) {
+						_this.executeCommand(event.results[i][0].transcript.trim().toLowerCase());
+					}
+				}
+			};
+		},
+
+		executeCommand: function (transcript) {
+			mw.log("aria::got transcript: " + transcript);
+			var command = null;
+			var playArr = [ "play" ];
+			if (playArr.indexOf(transcript) !== -1) {
+				command = "play";
+			}
+			var pauseArr = [ "pause", "pulse", "pose", "pose" , "both", "post", "phone", "pal", "pals", "Powell's", "pout" ];
+			if (pauseArr.indexOf(transcript) !== -1) {
+				command = "pause";
+			}
+			mw.log("aria::executing command: " + command);
+			if (command) {
+				switch (command) {
+					case "play":
+						this.embedPlayer.sendNotification("doPlay");
+						break;
+					case "pause":
+						this.embedPlayer.sendNotification("doPause");
+						break;
+				}
+			}
+		}
+	})
+
+	);
+
+})(window.mw, window.jQuery);

--- a/modules/KalturaSupport/components/aria/tts.php
+++ b/modules/KalturaSupport/components/aria/tts.php
@@ -1,0 +1,14 @@
+<?php
+
+$qs = http_build_query(array("ie" => "utf-8","tl" => $_GET["tl"], "q" => $_GET["q"]));
+$ctx = stream_context_create(array("http"=>array("method"=>"GET","header"=>"Referer: \r\n")));
+$soundfile = file_get_contents("http://translate.google.com/translate_tts?".$qs, false, $ctx);
+
+header("Content-type: audio/mpeg");
+header("Content-Transfer-Encoding: binary");
+header('Pragma: no-cache');
+header('Expires: 0');
+
+echo($soundfile);
+
+?>

--- a/modules/KalturaSupport/tests/Aria.html
+++ b/modules/KalturaSupport/tests/Aria.html
@@ -1,0 +1,36 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+	<title>Aria Player test</title>
+	<script type="text/javascript" src="../../../tests/qunit/qunit-bootstrap.js"></script>
+	<script type="text/javascript" src="../../../mwEmbedLoader.php"></script>
+	<script type="text/javascript" src="../../../docs/js/doc-bootstrap.js"></script>
+
+	<!-- qunit-kaltura must come after qunit-bootstrap.js and after mwEmbedLoader.php and after any jsCallbackReady stuff-->
+	<script type="text/javascript" src="resources/qunit-kaltura-bootstrap.js"></script>
+</head>
+<body>
+<h2> Aria Test </h2>
+
+<br/>
+
+<div id="playbackModeSelector"></div>
+<div id="kaltura_player" style="width:400px;height:330px;"></div>
+<script>
+	kWidget.embed({
+		'targetId': 'kaltura_player',
+		'wid': '_243342',
+		'uiconf_id': '12905712',
+		'entry_id': '0_uka1msg4',
+		'flashvars': {
+			'aria': {
+				"plugin": true,
+				"readTooltips": true,
+				"locale": "en",
+				"voiceCommands": true
+			}
+		}
+	});
+</script>
+</body>
+</html>


### PR DESCRIPTION
new plugin that reads tooltips on rollover and accepts voice commands (currently implemented only play and pause). Tooltip reding should work on all browsers that natively support MP3. Voice command recognition currently works only on Google Chrome.

pull request created for testing purposes only - DO NOT MERGE!
