### PR TITLE
Fix pluginsReady event

### DIFF
--- a/modules/KalturaSupport/UiConfResult.php
+++ b/modules/KalturaSupport/UiConfResult.php
@@ -531,6 +531,7 @@ class UiConfResult {
 		$plugins = array(
 			"topBarContainer" => array(),
 			"controlBarContainer" => array(),
+			"sideBarContainer" => array(),
 			"scrubber" => array(),
 			"largePlayBtn" => array(),
 			"playHead" => array(),


### PR DESCRIPTION
sideBarContainer is a container and always set in registered plugin
list - need to include in default uiConf - otherwise pluginsReady event
condition is never met
