### PR TITLE
#PS-1936

### DIFF
--- a/kWidget/kWidget.js
+++ b/kWidget/kWidget.js
@@ -894,12 +894,12 @@ var kWidget = {
 		// fix for iOS8 iframe overflow issue
 		var userAgent = navigator.userAgent;
 		var isIOS8 = ( /OS 8_/.test(userAgent) || /Version\/8/.test(userAgent) ) && ( userAgent.indexOf('iPad') != -1 || userAgent.indexOf('iPhone') != -1 );
-		if (isIOS8 && parseInt(widgetElm.style.height) > 0) {
-			try {
+		try {
+			if (isIOS8 && parseInt(widgetElm.style.height) > 0) {
 				iframe.style.height = widgetElm.style.height;
-			} catch (e) {
-				this.log("kWidget::error when trying to set iframe height: " + e.message);
 			}
+		} catch (e) {
+			this.log("Error when trying to set iframe height: " + e.message);
 		}
 
 		// Create the iframe proxy that wraps the actual iframe


### PR DESCRIPTION
set a fixed height for the iFrame due to known iOS8 issue where iframe with height 100% wrapped by div with fixed size gets the entire content height instead of the div height (https://www.google.co.il/search?q=iOS+iframe+height+issue&oq=iOS+iframe+height+issue&aqs=chrome..69i57j0j69i61l2.237j0j4&sourceid=chrome&es_sm=91&ie=UTF-8)

Note - this will disable responsiveness. However - we don't support responsiveness in iPhone and iPad. If we will have to support it in the future- we can set the height back to 100% on the layoutReady event.
