### PR TITLE
Used CURLFile instead "@"

### DIFF
--- a/modules/KalturaSupport/Client/kaltura_client_v3/KalturaClientBase.php
+++ b/modules/KalturaSupport/Client/kaltura_client_v3/KalturaClientBase.php
@@ -553,7 +553,7 @@ class KalturaClientBase
         return array($result, $curlError);
     }
 
-    /**
+       /**
 	 * HTTP stream context request
 	 *
 	 * @param string $url


### PR DESCRIPTION
Used CURLFile instead "@" while posting files if PHP version is >= 5.5 since it's deprecated.
