### PR TITLE
KMS-5027 #comment Define spinner DOM target  #time 4h

### DIFF
--- a/modules/EmbedPlayer/resources/mw.EmbedPlayer.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayer.js
@@ -2219,8 +2219,19 @@
 			$(this).trigger('onAddPlayerSpinner');
 			// remove any old spinner
 			$('#' + sId).remove();
+			var target = this;
+			switch(mw.getConfig("EmbedPlayer.SpinnerTarget")){
+				case "videoHolder":
+					target = this.getVideoHolder();
+					break;
+				case "videoDisplay":
+					target = this.getVideoDisplay();
+					break;
+				default:
+					target = this;
+			}
 			// re add an absolute positioned spinner:
-			$(this).getAbsoluteOverlaySpinner()
+			$(target).getAbsoluteOverlaySpinner()
 				.attr('id', sId);
 		},
 		hideSpinner: function () {

--- a/modules/KalturaSupport/components/dualScreen/dualScreen.js
+++ b/modules/KalturaSupport/components/dualScreen/dualScreen.js
@@ -422,11 +422,6 @@
 				this.bind( 'KalturaSupport_ThumbCuePointsReady', function () {
 					var currentCuepoint = _this.getCurrentCuePoint() || _this.getCuePoints()[0];
 					_this.sync(currentCuepoint , function(){
-						var $spinner = $( '#secondScreenLoadingSpinner' );
-						if ( $spinner.length > 0 ) {
-							// remove the spinner
-							$spinner.remove();
-						}
 						_this.secondDisplayReady = true;
 					} );
 				} );
@@ -569,26 +564,22 @@
 
 					this.positionSecondScreen();
 
-					var addSpinner = function () {
-						if ( !_this.secondDisplayReady && _this.render ) {
-							if ( mw.getConfig( "EmbedPlayer.LiveCuepoints" ) ) {
-								//TODO: add information slide for no current slide available
-							} else {
-								secondaryScreen.getAbsoluteOverlaySpinner().attr( 'id', 'secondScreenLoadingSpinner' );
-							}
+					var showLoadingSlide = function () {
+						if ( !_this.secondDisplayReady && _this.render && mw.getConfig( "EmbedPlayer.LiveCuepoints" ) ) {
+							//TODO: add information slide for no current slide available
 						}
 					};
 
 					if ( this.getConfig( "mainViewDisplay" ) == 2 ) {
 						this.bind( 'postDualScreenTransition.spinnerPostFix', function () {
 							_this.unbind( 'postDualScreenTransition.spinnerPostFix' );
-							addSpinner();
+							showLoadingSlide();
 						} );
 						setTimeout( function () {
 							_this.fsm.consumeEvent( "switchView" );
 						}, 500 );
 					} else {
-						addSpinner();
+						showLoadingSlide();
 					}
 
 					//dualScreen components are set on z-index 1-3, so set all other components to zIndex 4 or above


### PR DESCRIPTION
Dual screen adds transitions to mwEMbedPlayer div that holds the
spinner DIV so it moves when transitioned, so add ability to define
spinner DOM target and attach it to elements that don’t transition.
