### PR TITLE
Update play UI on initial stream change

### DIFF
--- a/modules/KalturaSupport/components/streamSelector.js
+++ b/modules/KalturaSupport/components/streamSelector.js
@@ -317,6 +317,7 @@
 						//Return poster to allow display of poster on clip done
 						mw.setConfig('EmbedPlayer.HidePosterOnStart', false);
 						embedPlayer.restoreEventPropagation();
+						embedPlayer.triggerHelper( "onPlayerStateChange", ["play"] );
 						embedPlayer.triggerHelper('onChangeStreamDone', [_this.currentStream.id]);
 					}
 				};


### PR DESCRIPTION
If starting playback by selecting a stream (and not from play) then the
event propagation is freezes and UI doesn’t change, so dispatch the UI
change event afterwards.
