### PR TITLE
FEC-2479 #comment Add fallback for adTagUrl evaluation by parts

### DIFF
--- a/modules/DoubleClick/resources/mw.DoubleClick.js
+++ b/modules/DoubleClick/resources/mw.DoubleClick.js
@@ -196,27 +196,35 @@
 				flashVars['countdownText'] = escape(flashVars['countdownText']); // escape countdownText to support & and ' characters
 			}
 			//Handle adTagUrl separately - using postProcessConfig on the entire ad tag breaks doubleclick functionality
-			var adTagUrl = embedPlayer.getRawKalturaConfig(pluginName, "adTagUrl");
-			if ( adTagUrl ){
-				//Break url to base and query string.
-				var adTagUrlParts = adTagUrl.split('?');
-				var adTagBaseUrl = adTagUrlParts[0];
-				var queryStringParams = adTagUrlParts[1];
-				var evaluatedQueryStringParams = "";
-				if (queryStringParams) {
-					//Break query string to key-value
-					var queryStringParamsParts = adTagUrlParts[1].split( '&' );
-					for ( var i = 0; i < queryStringParamsParts.length; i++ ) {
-						//Break query string to key-value pair
-						var pair = queryStringParamsParts[i].split( '=' );
-						//Unescape and try to evaluate key and value
-						var evaluatedKey   = embedPlayer.evaluate( unescape( pair[0] ) );
-						var evaluatedValue = embedPlayer.evaluate( unescape( pair[1] ) );
-						//Escape kvp and build evaluated query string param back
-						evaluatedQueryStringParams += escape( evaluatedKey ) + "=" + encodeURIComponent( evaluatedValue ) + "&";
+			try {
+				var adTagUrl = embedPlayer.getRawKalturaConfig( pluginName, "adTagUrl" );
+				if ( adTagUrl ) {
+					//Break url to base and query string.
+					var adTagUrlParts = adTagUrl.split( '?' );
+					var adTagBaseUrl = adTagUrlParts[0];
+					var queryStringParams = adTagUrlParts[1];
+					var evaluatedQueryStringParams = "";
+					if ( queryStringParams ) {
+						//Break query string to key-value
+						var queryStringParamsParts = adTagUrlParts[1].split( '&' );
+						for ( var i = 0; i < queryStringParamsParts.length; i++ ) {
+							//Break query string to key-value pair
+							var pair = queryStringParamsParts[i].split( '=' );
+							//Unescape and try to evaluate key and value
+							var evaluatedKey = embedPlayer.evaluate( unescape( pair[0] ) );
+							var evaluatedValue = embedPlayer.evaluate( unescape( pair[1] ) );
+							//Escape kvp and build evaluated query string param back
+							evaluatedQueryStringParams += escape( evaluatedKey ) + "=" + encodeURIComponent( evaluatedValue ) + "&";
+						}
+						//Build entire adTagUrl back and escape all of it to prevent flash string parsing error
+						flashVars['adTagUrl'] = escape( adTagBaseUrl + "?" + evaluatedQueryStringParams );
 					}
-					//Build entire adTagUrl back and escape all of it to prevent flash string parsing error
-					flashVars['adTagUrl'] = escape(adTagBaseUrl + "?" + evaluatedQueryStringParams);
+				}
+			} catch (e) {
+				// in case of error - fallback for fully escaped and evaluated adTagUrl string
+				this.log("failed to evaluate adTagUrl parts, using fully escaped/evaluated adTagUrl");
+				if ( flashVars['adTagUrl'] ){
+					flashVars['adTagUrl'] = escape(flashVars['adTagUrl']); // escape adTagUrl to prevent Flash string parsing error
 				}
 			}
 			//we shouldn't send these params, they are unnecessary and break the flash object


### PR DESCRIPTION
In case of error - use previous method of using fully escaped and
evaluated adTagUrl
