### PR TITLE
FEC-2318 -- DFP resume ad without opening clickthrough URL

### DIFF
--- a/modules/DoubleClick/resources/mw.DoubleClick.js
+++ b/modules/DoubleClick/resources/mw.DoubleClick.js
@@ -364,6 +364,20 @@
 		pauseAd: function (isLinear) {
 			var _this = this;
 			this.embedPlayer.paused = true;
+			var classes = "adCover";
+			if (mw.isIE8()){
+				classes += " adCoverIE8";
+			}
+			var adCover = $('<div class="' + classes + '"></div>').on('click', function(){
+				_this.embedPlayer.hideSpinnerOncePlaying();
+				_this.resumeAd(isLinear)
+			});
+			$(".adCover").remove();
+			if (this.isChromeless){
+				$(".videoDisplay").prepend(adCover);
+			}else{
+				$(this.getAdContainer()).append(adCover);
+			}
 			$(this.embedPlayer).trigger("onPlayerStateChange", ["pause", this.embedPlayer.currentState]);
 
 			if (isLinear) {
@@ -382,6 +396,7 @@
 		resumeAd: function (isLinear) {
 			var _this = this;
 			this.embedPlayer.paused = false;
+			$(".adCover").remove();
 			$(this.embedPlayer).trigger("onPlayerStateChange", ["play", this.embedPlayer.currentState]);
 			if (isLinear) {
 				this.embedPlayer.disablePlayControls();

--- a/skins/kdark/css/layout.css
+++ b/skins/kdark/css/layout.css
@@ -1077,6 +1077,17 @@ box-shadow:  0px 1px 0px rgba(0, 0, 0, 0.3);
     animation:spin 3s linear infinite;
 	outline: 0 !important;
 }
+.adCover{
+	position: fixed;
+	cursor: pointer;
+	width: 100%;
+	height: 100%;
+	background-color: rgba(0,0,0,0);
+}
+.adCoverIE8{
+	background-color: black;
+	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=0)";
+}
 .cssChecker{
 	display: none !important;
 }


### PR DESCRIPTION
added transparent layer over ad after ad click to capture clicks and resume ad playback without reopening the clickthrough URL
