### PR TITLE
#SUP-3067 #comment fix default captions selection #time 2h

### DIFF
--- a/modules/KalturaSupport/resources/mw.ClosedCaptions.js
+++ b/modules/KalturaSupport/resources/mw.ClosedCaptions.js
@@ -386,6 +386,14 @@
 					return ;
 				}				
 			}
+            // Get source by "default" property
+            if ( !this.selectedSource ) {
+                source = this.selectDefaultSource();
+                if( source ){
+                    this.log('autoSelectSource: select by default caption');
+                    this.selectedSource = source;
+                }
+            }
 			// Get from $_SERVER['HTTP_ACCEPT_LANGUAGE']
 			if( !this.selectedSource && mw.getConfig('Kaltura.UserLanguage') ){
 				$.each(mw.getConfig('Kaltura.UserLanguage'), function(lang, priority){
@@ -396,14 +404,6 @@
 						return true;
 					}
 				});
-			}
-			// Get source by "default" property
-			if ( !this.selectedSource ) {
-				source = this.selectDefaultSource();
-				if( source ){
-					this.log('autoSelectSource: select by default caption');
-					this.selectedSource = source;
-				}
 			}
 			// Else, get the first caption
 			if( !this.selectedSource ){


### PR DESCRIPTION
default captions were not selected because user.language was checked first and preferred over it
