### PR TITLE
Template enhancements

### DIFF
--- a/modules/KalturaSupport/UiConfResult.php
+++ b/modules/KalturaSupport/UiConfResult.php
@@ -18,7 +18,10 @@ class UiConfResult {
 	var $playerConfig = null;
 	var $noCache = null;
 	var $isPlaylist = null;
-	var $isJsonConfig = null;	
+	var $isJsonConfig = null;
+
+	// These properties are handled differently, we don't want to resolve them automatically
+	var $propsToIgnoreWhenResolvingResource = array('templatePath');
 	
 	function __construct( $request, $client, $cache, $logger, $utility ) {
 
@@ -240,6 +243,7 @@ class UiConfResult {
 				$this->walkThroughPluginAttributes( $attrValue , $refrencePathInObject[$attrKey] );
 			}
 			else {
+				if( in_array($attrKey, $this->propsToIgnoreWhenResolvingResource) ) continue;
 			    $refrencePathInObject[$attrKey] = $this->resolveCustomResourceUrl( $attrValue );
 			}
 		}

--- a/modules/KalturaSupport/resources/mw.KBasePlugin.js
+++ b/modules/KalturaSupport/resources/mw.KBasePlugin.js
@@ -79,6 +79,7 @@ mw.KBasePlugin = Class.extend({
 		data.player = this.embedPlayer;
 		data.entry = this.embedPlayer.kalturaPlayerMetaData;
 		data.entryMetadata = this.embedPlayer.kalturaEntryMetaData;
+		data.helpers = mw.util.getTemplateHelpers();
 
 		// First get template from 'template' config
 		var rawHTML = this.getConfig( 'template', true );

--- a/resources/mediawiki/mediawiki.util.tmpl.js
+++ b/resources/mediawiki/mediawiki.util.tmpl.js
@@ -6,6 +6,14 @@
 	"use strict";
 
 	var cache = {};
+	var helpers = {};
+	mw.util.registerTemplateHelper = function( name, callback ){
+		helpers[ name ] = callback;
+	};
+
+	mw.util.getTemplateHelpers = function(){
+		return helpers;
+	};
 	
 	mw.util.tmpl = function(str, data){
 		// Figure out if we're getting a template, or if we need to


### PR DESCRIPTION
This pull request add few enhancements for tempates.

1. Allow loading template files from ```kwidget-ps``` by using ```{html5ps}``` prefix.
2. Support for registering template helpers.

In ```myPlugin.js```:
```javascript
mw.util.registerTemplateHelper('trDateFormat', function( unixTimestamp ){
	var d = new Date(unixTimestamp*1000);
	var months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
	var year = d.getFullYear();
	var month = months[d.getMonth()];
	var day = d.getDate();
	var hour = d.getHours();
	var min = d.getMinutes();
	var sec = d.getSeconds();
	return day + '-' + month + '-' + year + ' ' + hour + ':' + min;
});
```

In ```myTemplate.html```:
```html
<span>Entry created at: <%=helpers.trDateFormat(entry.createdAt);%></span>
```

Please review & merge
