### PR TITLE
FEC-2647 --  Use the original ad duration

### DIFF
--- a/modules/KalturaSupport/resources/mw.KAdPlayer.js
+++ b/modules/KalturaSupport/resources/mw.KAdPlayer.js
@@ -1148,11 +1148,6 @@ mw.KAdPlayer.prototype = {
 			}
 			var time =  videoPlayer.currentTime;
 			var dur = videoPlayer.duration;
-			if (_this.getVPAIDDurtaion)
-			{
-				//we need to add time since we get the duration that left.
-				dur = _this.getVPAIDDurtaion() + time;
-			}
 
 			// Update the timeRemaining sequence proxy
 			_this.embedPlayer.adTimeline.updateSequenceProxy( 'timeRemaining', Math.round ( dur - time ) );


### PR DESCRIPTION
don't update video duration using the VPAID object remaining time + current time. Use the original ad duration instead.