### PR TITLE
FEC-2600 #comment Sync slides on DVR sync #time 4h

### DIFF
--- a/modules/KalturaSupport/components/dualScreen/dualScreen.js
+++ b/modules/KalturaSupport/components/dualScreen/dualScreen.js
@@ -411,7 +411,7 @@
 				//In live mode wait for first updatetime that is bigger then 0 for syncing initial slide
 				if (mw.getConfig("EmbedPlayer.LiveCuepoints")) {
 					this.bind( 'timeupdate', function ( ) {
-						if (_this.getPlayer().currentTime > 0) {
+						if (!_this.getPlayer().isDVR() && _this.getPlayer().currentTime > 0) {
 							_this.unbind('timeupdate');
 						}
 						var cuePoint = _this.getCurrentCuePoint();


### PR DESCRIPTION
Live with DVR doesn’t dispatch seek event on going back to live so keep
listening to time update for timeline sync