### PR TITLE
SUP-4096 #comment Validate destroy player before send notification

### DIFF
--- a/kWidget/kWidget.js
+++ b/kWidget/kWidget.js
@@ -245,7 +245,10 @@
 			// Support closing menu inside the player
 			if (!mw.getConfig('EmbedPlayer.IsIframeServer')) {
 				document.onclick = function () {
-					player.sendNotification('onFocusOutOfIframe');
+					//If player is destroyed don't send notification
+					if (!_this.destroyedWidgets[ player.id ]) {
+						player.sendNotification( 'onFocusOutOfIframe' );
+					}
 				};
 			}
 			// Check for proxied jsReadyCallback:


### PR DESCRIPTION
Note that issue is more complex as the existence of the player object means we actually don’t clean out the player properly!