### PR TITLE
FEC-3132 - white-lable captions languages

### DIFF
--- a/modules/KalturaSupport/resources/mw.ClosedCaptions.js
+++ b/modules/KalturaSupport/resources/mw.ClosedCaptions.js
@@ -11,6 +11,7 @@
 			"layout": "ontop", // "below"
 			"displayCaptions": null, // null will use user preference
 			"defaultLanguageKey": null,
+			"whiteListLanguagesCodes": null, //white list the languages by languages codes (e.g. 'en,fr' will remove all items but English and French if they exist)
 			"useCookie": true,
 			"hideWhenEmpty": false,
 			"showEmbeddedCaptions": false,
@@ -312,7 +313,26 @@
 			}, function( data ) {
 				mw.log( "mw.ClosedCaptions:: loadCaptionsFromApi: " + data.totalCount, data.objects );
 				if( data.objects && data.objects.length ){
+					// white list languages by their label
+					if( _this.getConfig("whiteListLanguagesCodes") != null){
+						mw.log( "mw.ClosedCaptions:: whitelist : " + _this.getConfig("whiteListLanguagesCodes") );
+						var whiteListedLaguages = new Array();
+						var whiteListArr = _this.getConfig("whiteListLanguagesCodes").split(",");
+						for(var j=0 ; j<whiteListArr.length ; j++){
+							for(var i=data.objects.length-1 ; i > -1 ; i--){
+								if( data.objects[i].languageCode == whiteListArr[j]){
+									whiteListedLaguages.push(data.objects[i]);
+								}
+							}
+						}
+						data.objects = whiteListedLaguages;
+						if(!data.objects.length && _this.getConfig("hideWhenEmpty") == true){
+							_this.getBtn().hide();
+						}
+
+					}
 					_this.loadCaptionsURLsFromApi( data.objects, callback );
+
 				} else {
 					// No captions
 					callback([]);

--- a/modules/KalturaSupport/tests/ClosedCaptions.html
+++ b/modules/KalturaSupport/tests/ClosedCaptions.html
@@ -69,11 +69,12 @@ kdp.sendNotification( 'showHideClosedCaptions');
 		'targetId': 'myVideoTarget',
 		'wid': '_243342',
 		'uiconf_id': '20540612',
-		'entry_id': '1_23pqn2nu',
+		'entry_id': '0_uka1msg4',
 		'flashvars': {
 			'disableTrackElement': true,
 			'closedCaptions': {
 				'hideWhenEmpty': true,
+                'whiteListLanguagesCodes': 'en,es,fr,jp',
 				'layout': 'ontop',
 				'useCookie': true,
 				'defaultLanguageKey': 'en',

--- a/modules/KalturaSupport/tests/ClosedCaptions.qunit.html
+++ b/modules/KalturaSupport/tests/ClosedCaptions.qunit.html
@@ -113,13 +113,14 @@
 		'targetId': 'myVideoTarget',
 		'wid': '_243342',
 		'uiconf_id': '12907572',
-		'entry_id': '1_1dvx5zaw',
+		'entry_id': '0_uka1msg4',
 		'flashvars': {
 			'disableTrackElement': true,
 			'closedCaptions': {
 				'layout': 'ontop',
 				'useCookie': true,
 				'defaultLanguageKey': 'en',
+                'whiteListLanguagesCodes': 'en,es,fr,jp',
 				'fontsize': 12,
 				'bg' : '0x335544',
 				'fontFamily' : 'Arial',


### PR DESCRIPTION
Added the ability to define white-labeled array of languages code (E.G. 'whiteListLanguagesCodes': 'en,es,fr,jp'). This configuration will remove all languages but the ones in this list. If the player did not get this attribute it will not interfere with the logic. 
2 test pages were updated to point to the "instant folgers" and new captions files were uploaded to that entry. I highly recommend QA to use this entry (0_uka1msg4) as the entry for testing Captions languages (and sync as well). 

Without white label: 
http://kgit.html5video.org/pulls/1604/modules/KalturaSupport/tests/ClosedCaptions.html#config%3D%7B%22flashvars%22%3A%7B%22closedCaptions%22%3A%7B%22whiteListLanguagesCodes%22%3A%22%22%2C%22useGlow%22%3Afalse%7D%7D%7D

With white label:
http://kgit.html5video.org/pulls/1604/modules/KalturaSupport/tests/ClosedCaptions.html