### PR TITLE
Force caption loading

### DIFF
--- a/modules/KalturaSupport/resources/mw.ClosedCaptions.js
+++ b/modules/KalturaSupport/resources/mw.ClosedCaptions.js
@@ -431,7 +431,7 @@
 			// Found caption
 			if( source && !source.loaded ) {
 				source.load($.proxy(function(){
-					this.getPlayer().triggerHelper('newClosedCaptionsData', source);
+					this.getPlayer().triggerHelper('forcedCaptionLoaded', source);
 				},this));
 			}
 		},

--- a/modules/KalturaSupport/resources/mw.ClosedCaptions.js
+++ b/modules/KalturaSupport/resources/mw.ClosedCaptions.js
@@ -20,7 +20,9 @@
 			"showOffButton": true,
 			"toggleActiveCaption": false,
 			"useExternalClosedCaptions": false,
-			"offButtonPosition": "first"
+			"offButtonPosition": "first",
+			// Can be used to force loading specific language and expose to other plugins
+			"forceLoadLanguage": false
 		},
 
 		textSources: [],
@@ -287,6 +289,11 @@
 					_this.textSources = textSources;
 				}]);
 
+				// Handle Force loading of captions
+				if( _this.getConfig('forceLoadLanguage') ) {
+					_this.forceLoadLanguage();
+				}
+
 				if( _this.getConfig('displayCaptions') !== false || ($.cookie( _this.cookieName ) !== 'None' && $.cookie( _this.cookieName )) ){
 					_this.autoSelectSource();
 					if( _this.selectedSource ){
@@ -417,6 +424,16 @@
 			);
 			// Return a "textSource" object:
 			return new mw.TextSource( embedSource );
+		},
+		forceLoadLanguage: function(){
+			var lang = this.getConfig('forceLoadLanguage');
+			var source = this.selectSourceByLangKey( lang );
+			// Found caption
+			if( source && !source.loaded ) {
+				source.load($.proxy(function(){
+					this.getPlayer().triggerHelper('newClosedCaptionsData', source);
+				},this));
+			}
 		},
 		autoSelectSource: function(){
 			var _this = this;


### PR DESCRIPTION
This pull request adds the ability to force the ```ClosedCaption``` plugin to load specific caption by language and trigger event so other plugins can use it.

### How to use
We have new configuration ```forceLoadLanguage``` configuration.
```
closedCaptions.forceLoadLanguage=en
```

This try to find a caption using the "en" as language key, If found we will trigger (new) ```forcedCaptionLoaded``` event.

**These additions does not change anything in the UI or the behavior of the plugin, everything stays the same.**

@itaykinnrot  
Please review & merge