### PR TITLE
Expose Share API for plugins

### DIFF
--- a/modules/KalturaSupport/components/share/ShareAPI.html
+++ b/modules/KalturaSupport/components/share/ShareAPI.html
@@ -28,6 +28,11 @@
 		$('#triggerShareOffset').click(function () {
 			window.kdp.sendNotification('doShare',{"timeOffset":"30"});
 		});
+
+		$('#shareByPlayform').click(function (){
+			var network = $('#selectPlatform').val();
+			window.kdp.sendNotification('shareByPlatform', network);
+		});
 	}
 
 
@@ -72,7 +77,17 @@ kWidget.addReadyCallback(function( playerId ){
 });
 </pre>
 Trigger Share event: <button id="triggerShare" href="#">GO</button><br>
-Trigger Share event with time offset of 30 seconds: <button id="triggerShareOffset" href="#">GO</button>
+Trigger Share event with time offset of 30 seconds: <button id="triggerShareOffset" href="#">GO</button><br/>
+<p>
+	Trigger Share for Platform:
+	<select id="selectPlatform">
+		<option value="facebook">facebook</option>
+		<option value="twitter">twitter</option>
+		<option value="googleplus">googleplus</option>
+		<option value="email">email</option>
+		<option value="linkedin">linkedin</option>
+	</select>&nbsp;
+	<button id="shareByPlayform">Go</button>
 <br><br>
 <b>Shared Link:</b>
 <pre id="shareLink" class="prettyprint" style="display: none"></pre>

--- a/modules/KalturaSupport/components/share/ShareAPI.html
+++ b/modules/KalturaSupport/components/share/ShareAPI.html
@@ -57,9 +57,10 @@
 <div style="clear:both"></div>
 <h3> Share plugin API </h3>
 <p>
-The Share plugin provides JavaScript API for triggering the shared link generation and retrieving it:<br><br>
+The Share plugin provides JavaScript API for triggering the shared link generation and retrieval as well as invoking the share operation itself:<br><br>
 <b>"doShare" Notification: </b>is used to trigger the shared link generation. You can specify the required time offset by sending a configuration object, for example: { "timeOffset" : "30" }<br>
-<b>"shareEvent" Event: </b>is triggered by the plugin once the shared link is generated. It provides access to the 	generated shared link by accessing the event's "sharedLink" property.
+<b>"shareEvent" Event: </b>is triggered by the plugin once the shared link is generated. It provides access to the 	generated shared link by accessing the event's "sharedLink" property.<br>
+<b>"shareByPlatform" Notification: </b>is used to invoke the share operation without displaying the Share UI on top of the player. The required network is send as a parameter.
 </p>
 <br>
 Sample code for Share API:
@@ -74,13 +75,17 @@ kWidget.addReadyCallback(function( playerId ){
 	kdp.sendNotification( 'doShare' );
 	// trigger share event with time offset
 	kdp.sendNotification( 'doShare', { "timeOffset" : "30" } );
+	// trigger shareByPlatform event
+	kdp.sendNotification( 'shareByPlatform', 'facebook' );
 });
 </pre>
 Trigger Share event: <button id="triggerShare" href="#">GO</button><br>
 Trigger Share event with time offset of 30 seconds: <button id="triggerShareOffset" href="#">GO</button><br/>
+<b>Generated Shared Link:</b>
+<pre id="shareLink" class="prettyprint"> </pre>
 <p>
 	Trigger Share for Platform:
-	<select id="selectPlatform">
+	<select id="selectPlatform" style="margin-top: 9px">
 		<option value="facebook">facebook</option>
 		<option value="twitter">twitter</option>
 		<option value="googleplus">googleplus</option>
@@ -89,8 +94,6 @@ Trigger Share event with time offset of 30 seconds: <button id="triggerShareOffs
 	</select>&nbsp;
 	<button id="shareByPlayform">Go</button>
 <br><br>
-<b>Shared Link:</b>
-<pre id="shareLink" class="prettyprint" style="display: none"></pre>
 <br/><br/>
 </body>
 </html>

--- a/modules/KalturaSupport/components/share/share.js
+++ b/modules/KalturaSupport/components/share/share.js
@@ -412,7 +412,7 @@
 		openPopup: function (e, network) {
 
 			// Maintain backward compatibility 
-			if( network === undefined ) {
+			if( e && e.originalEvent ) {
 				network = {
 					id: $(e.target).attr('id'),
 					url: $(e.target).parents('a').attr('href')


### PR DESCRIPTION
This pull request adds the ability to use Share plugin via other plugins.

```js
window.kdp.sendNotification('shareByPlatform','facebook');
```

[See test page for example.](http://kgit.html5video.org/pulls/1732/modules/KalturaSupport/components/share/ShareAPI.html)

@itaykinnrot @amirch1 @eitanavgil 
Please review & merge