### PR TITLE
Playlist sticky controls

### DIFF
--- a/modules/KalturaSupport/components/playlist/playList.css
+++ b/modules/KalturaSupport/components/playlist/playList.css
@@ -215,6 +215,10 @@
 	z-index: 3;
 }
 
+.playlistAPI .k-chapters-container.sticky-controls .k-scroll {
+	opacity: 1;
+}
+
 .playlistAPI .k-chapters-container.k-horizontal .k-scroll.k-next {
 	right: 0px;
 	top: 0px;
@@ -309,7 +313,9 @@
 	height: 20px;
 	position: absolute;
 }
-
+.playlistAPI .sticky-controls .k-carousel {
+	margin: 0 20px;
+}
 .playlistAPI .k-chapters-container.k-vertical .k-carousel {
 	float: none;
 }

--- a/modules/KalturaSupport/components/playlistAPI.js
+++ b/modules/KalturaSupport/components/playlistAPI.js
@@ -32,7 +32,8 @@
 			'includeHeader': true,
 			'renderWhenEmpty': false,
 			'paging': false,
-			'pageSize': 25
+			'pageSize': 25,
+			'stickyControls': false
 		},
 
 
@@ -198,7 +199,7 @@
 
 									if (_this.getLayout() === "horizontal"){
 										_this.getMedialistComponent().find('ul').width((_this.getMediaItemBoxWidth()+1)*_this.mediaList.length);
-										_this.getMedialistComponent().find('.k-carousel').css('width', _this.getMedialistComponent().width() );
+										//_this.getMedialistComponent().find('.k-carousel').css('width', _this.getMedialistComponent().width() );
 
 										var scrollLeft = Math.abs(parseInt(_this.getComponent().find("ul").css("left")));
 										var hiddenItems = parseInt(scrollLeft / _this.getConfig( 'mediaItemWidth'));
@@ -299,7 +300,7 @@
 						}
 					}
 				}else{
-					this.setConfig( 'mediaItemWidth', Math.floor($( ".playlistInterface" ).width() / this.getConfig("MinClips")) );
+					this.setConfig( 'mediaItemWidth', Math.floor(this.getCarouselWidth() / this.getConfig("MinClips")) );
 				}
 				if ( this.getConfig('onPage') !== true ){ // do not refresh mediaListContainer on page
 					this.$mediaListContainer = null;

--- a/modules/KalturaSupport/resources/mw.KBaseMediaList.js
+++ b/modules/KalturaSupport/resources/mw.KBaseMediaList.js
@@ -183,18 +183,26 @@
 					}
 
 					if ( this.getConfig( 'containerPosition' ) == 'top' || this.getConfig( 'containerPosition' ) == 'bottom' ) {
-						var playlistHeight = this.getLayout() === "vertical" ? this.getConfig( "mediaItemHeight" ) * this.getConfig( "MinClips" ) + this.getMedialistHeaderComponent().height() : this.getConfig( "mediaItemHeight" ) + this.getConfig('horizontalHeaderHeight');
+						var playlistHeight = this.getPlaylistHeightBasedOnLayout();
 						this.getComponent().height(playlistHeight);
-						$( ".mwPlayerContainer" ).css( "height", this.$mediaListContainer.height() - playlistHeight + "px" );
-						var controlBarHeight = 0;
-						$('.block').each(function() {
-							controlBarHeight += $( this ).outerHeight( true ); // add height of each components container that is not hovering
+						var blockElementsHeight = 0;
+						this.$mediaListContainer.find('> .block').each(function(){
+							blockElementsHeight += $( this ).outerHeight( true );
 						});
-						this.getPlayer().getVideoHolder().css( "height", this.$mediaListContainer.height() - playlistHeight - controlBarHeight + "px" );
+						$( ".mwPlayerContainer" ).css( "height", this.$mediaListContainer.height() - blockElementsHeight - playlistHeight + "px" );
+						this.getPlayer().doUpdateLayout(true);
 					}
 				}
 			}
 			return this.$mediaListContainer;
+		},
+		getPlaylistHeightBasedOnLayout: function(){
+			var itemHeight = this.getConfig( "mediaItemHeight" )
+			if( this.getLayout() === "vertical" ) {
+				return itemHeight * this.getConfig( "MinClips" ) + this.getMedialistHeaderComponent().height();
+			} else {
+				return itemHeight + this.getConfig('horizontalHeaderHeight');
+			} 
 		},
 		// set the size of the playlist container and the video
 		setMedialistContainerSize: function(){

--- a/modules/KalturaSupport/resources/mw.KBaseMediaList.js
+++ b/modules/KalturaSupport/resources/mw.KBaseMediaList.js
@@ -37,7 +37,8 @@
 				'minDisplayWidth': 0,
 				'minDisplayHeight': 0,
 				'horizontalScrollItems': 1,
-				'scrollerCssPath': "resources/nanoScroller/nanoScroller.css"
+				'scrollerCssPath': "resources/nanoScroller/nanoScroller.css",
+				'stickyControls': false
 			});
 		},
 
@@ -580,10 +581,11 @@
 			}else {
 				this.addScrollUiComponents();
 				var $cc = this.getMedialistComponent();
+				var $kcarousel = $cc.find('.k-carousel');
 				this.mediaItemVisible = this.calculateVisibleScrollItems();
 				var speed = mw.isTouchDevice() ? 100: 200;
 				// Add scrolling carousel to clip list ( once dom sizes are up-to-date )
-				$cc.find( '.k-carousel' ).jCarouselLite( {
+				$kcarousel.jCarouselLite( {
 					btnNext: '.k-next',
 					btnPrev: '.k-prev',
 					visible: this.mediaItemVisible,
@@ -597,8 +599,24 @@
 						$(_this.embedPlayer).trigger("scrollEnd");
 					});
 				$cc.find('ul').width((this.getMediaItemBoxWidth()+1)*this.mediaList.length);
-				$cc.find('.k-carousel').css('width', $cc.width() );
+
+				$kcarousel.css('width', this.getCarouselWidth() );
+				if( this.getConfig('stickyControls') ) {
+					$cc.addClass('sticky-controls');
+					this.setMediaBoxesDimensions();
+				}
 			}
+		},
+		getCarouselWidth: function(){
+			var $cc = this.getMedialistComponent();
+			var width = $cc.width();
+			if( !this.getConfig('stickyControls') ) {
+				return width;
+			}
+			$cc.find('.k-prev,.k-next').each(function(){
+				width -= $(this).outerWidth(true);
+			});
+			return 391;
 		},
 		getScrollComponent: function(){
 			if (!this.$scroll){
@@ -664,6 +682,12 @@
 					.addClass( "k-scroll k-next" )
 			);
 
+			if( ! this.getConfig('stickyControls') ) {
+				this.addHoverControls();
+			}
+		},
+		addHoverControls: function(){
+			var $cc = this.getMedialistComponent();
 			// Add media item hover to hide show play buttons:
 			var inKBtn = false;
 			var inContainer = false;


### PR DESCRIPTION
Hi All,

This pull request adds new feature called ```stickyControl``` for ```PlaylistAPI``` plugin.
```json
{
  "playlistAPI": {
    "stickyControls": true
  }
}
```

When enabling ```stickyControls``` the playlist carousel ```Back``` and ```Next``` buttons will stick to the sides of the carousel and will make the carousel smaller.

![screen shot 2015-05-12 at 14 37 27](https://cloud.githubusercontent.com/assets/1016375/7586320/7a3e78c2-f8b4-11e4-8fb6-3884ee5a4bd6.png)

Please review & merge

@itaykinnrot @amirch1 @mdale @eitanavgil 