### PR TITLE
FEC-3559 #comment Allow override domain for player server

### DIFF
--- a/LocalSettings.KalturaPlatform.php
+++ b/LocalSettings.KalturaPlatform.php
@@ -77,6 +77,14 @@ if( $kConf->hasMap('playReady') ) {
 		$wgKalturaLicenseServerUrl = $playReadyMap['license_server_url'];
 }
 
+if( $kConf->hasParam('overrideDomain') ) {
+	$wgEnableKalturaOverrideDomain = $kConf->get('overrideDomain');
+}
+
+if( $kConf->hasParam('overrideDomains') ) {
+	$wgKalturaAuthReverseProxyDomains = $kConf->get('overrideDomains');
+}
+
 // A helper function to get full URL of host
 function wgGetUrl( $hostKey = null ) {
 	global $wgHTTPProtocol, $wgServerPort, $kConf;

--- a/includes/DefaultSettings.php
+++ b/includes/DefaultSettings.php
@@ -241,12 +241,32 @@ $wgRemoteWebInspector = false;
 $wgKalturaApiFeatures = array();
 
 /*********************************************************
+ * Override Domain:
+********************************************************/
+$wgEnableKalturaOverrideDomain = true;
+$wgKalturaAuthOverrideDomains = array();
+
+/*********************************************************
  * Include local settings override:
 ********************************************************/
 $wgLocalSettingsFile = realpath( dirname( __FILE__ ) ) . '/../LocalSettings.php';
 
 if( is_file( $wgLocalSettingsFile ) ){
 	require_once( $wgLocalSettingsFile );
+}
+
+//Override Domain
+//===============
+//Override here all variables that are using wgServer
+if (isset( $_GET['od'] ) && $wgEnableKalturaOverrideDomain && in_array($_SERVER['HTTP_HOST'], $wgKalturaAuthOverrideDomains )){
+	$wgServer = htmlspecialchars( $_GET['rp'] ) . dirname( dirname( $_SERVER['SCRIPT_NAME'] ) ) .'/';
+
+	// Default Load Script path
+    $wgLoadScript = $wgServer . $wgScriptPath . 'load.php';
+    // Support legacy $wgResourceLoaderUrl url.
+    $wgResourceLoaderUrl = $wgLoadScript;
+
+    $wgMwEmbedProxyUrl =  $wgServer . $wgScriptPath . 'simplePhpXMLProxy.php';
 }
 
 //Set global configs into $wgMwEmbedModuleConfig in order to enable


### PR DESCRIPTION
This will enable changing the load script domain.
In order to set the ServiceUrl, CdnUrl or other client side Urls please
use mw.setConfig