### PR TITLE
SUP-4857

### DIFF
--- a/modules/KalturaSupport/components/theme.js
+++ b/modules/KalturaSupport/components/theme.js
@@ -24,6 +24,9 @@
 			// update drop shadow after the layout is ready
 			this.bind('layoutBuildDone', function(){
 				_this.onConfigChange('buttonsIconColorDropShadow', _this.getConfig('buttonsIconColorDropShadow'));
+				if ( mw.isIE() ){
+					$(".btn").not(".playHead").css({'margin-left': 1+'px','margin-right': 1+'px'});
+				}
 			});
 		},
 		onConfigChange: function( property, value ){

--- a/skins/kdark/css/layout.css
+++ b/skins/kdark/css/layout.css
@@ -796,6 +796,7 @@ body {
 	background-color: transparent;
 	color: #ccc;
 	text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.8);
+	outline-offset: -1px;
 }
 
 .btn:hover {


### PR DESCRIPTION
set outline to -1px for all buttons. For IE only (which doesn't support outline-offset negative values) - set left and right margins of 1px only when using the theme plugin (opaque background)