### PR TITLE
Add support for DRM on the fly flavor selection

### DIFF
--- a/modules/EmbedPlayer/resources/mw.MediaSource.js
+++ b/modules/EmbedPlayer/resources/mw.MediaSource.js
@@ -74,7 +74,8 @@
 		'srclang',
 		'data-custom_data',
 		'data-signature',
-		'data-contentId'
+		'data-contentId',
+		'data-flavors'
 
 	]);
 

--- a/modules/KalturaSupport/resources/mw.KWidgetSupport.js
+++ b/modules/KalturaSupport/resources/mw.KWidgetSupport.js
@@ -1537,7 +1537,8 @@ mw.KWidgetSupport.prototype = {
 					'data-aspect' : validClipAspect,
 					'data-flavorid' : 'mpdLow',
 					'type' : 'application/dash+xml',
-					'src' : flavorUrl + '/entryId/' + asset.entryId + '/flavorIds/' + iphoneAdaptiveFlavors.join(',')  + '/format/MPEGDASH/protocol/' + protocol + '/a.mpd'
+					'src' : flavorUrl + '/entryId/' + asset.entryId + '/flavorIds/' + iphoneAdaptiveFlavors.join(',')  + '/format/MPEGDASH/protocol/' + protocol + '/a.mpd',
+					'data-flavors': iphoneAdaptiveFlavors.join(',')
 				};
 				assetId = iphoneAdaptiveFlavors[0];
 				assetDrmData = this.getSourceDrmData(assetId, flavorDrmData);
@@ -1556,7 +1557,8 @@ mw.KWidgetSupport.prototype = {
 					'data-aspect' : validClipAspect,
 					'data-flavorid' : 'mpdHigh',
 					'type' : 'application/dash+xml',
-					'src' : flavorUrl + '/entryId/' + asset.entryId + '/flavorIds/' + ipadAdaptiveFlavors.join(',')  + '/format/MPEGDASH/protocol/' + protocol + '/a.mpd'
+					'src' : flavorUrl + '/entryId/' + asset.entryId + '/flavorIds/' + ipadAdaptiveFlavors.join(',')  + '/format/MPEGDASH/protocol/' + protocol + '/a.mpd',
+					'data-flavors': ipadAdaptiveFlavors.join(',')
 				};
 				assetId = ipadAdaptiveFlavors[0];
 				assetDrmData = this.getSourceDrmData(assetId, flavorDrmData);

--- a/modules/MultiDRM/resources/mw.EmbedPlayerMultiDRM.js
+++ b/modules/MultiDRM/resources/mw.EmbedPlayerMultiDRM.js
@@ -291,6 +291,10 @@
 				custom_data: this.mediaElement.selectedSource["custom_data"],
 				signature: this.mediaElement.selectedSource["signature"]
 			};
+			if (this.mediaElement.selectedSource.flavors){
+				licenseData.files = encodeURIComponent(window.btoa(this.mediaElement.selectedSource.flavors));
+			}
+
 			var licenseDataString = "";
 			if (licenseData) {
 				$.each( licenseData, function ( key, val ) {


### PR DESCRIPTION
uDRM needs to know which exact flavors were selected for playback from
the available flavors returned to player by contextData request