### PR TITLE
FEC-3684

### DIFF
--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerKplayer.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerKplayer.js
@@ -367,7 +367,7 @@
 		onPlay: function () {
 			if ( mw.isChrome() && !this.flashActivationRequired && mw.getConfig("EmbedPlayer.EnableFlashActivation") !== false ){
 				this.flashActivationRequired = true;
-				$(".mwEmbedPlayer").hide();
+				$(this).hide();
 			}
 			if (this._propagateEvents) {
 				$(this).trigger("playing");
@@ -541,7 +541,7 @@
 		onUpdatePlayhead: function (playheadValue) {
 			if ( this.flashActivationRequired ){
 				this.flashActivationRequired = false;
-				$(".mwEmbedPlayer").show();
+				$(this).show();
 			}
 			if (this.seeking) {
 				this.seeking = false;

--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerKplayer.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerKplayer.js
@@ -37,6 +37,7 @@
 		//when playing live rtmp we increase the timeout until we display the "offline" alert, cuz player takes a while to identify "online" state
 		LIVE_OFFLINE_ALERT_TIMEOUT: 8000,
 		ignoreEnableGui: false,
+		flashActivationRequired: false,
 
 		// Create our player element
 		setup: function (readyCallback) {
@@ -364,6 +365,10 @@
 		 * parent_play
 		 */
 		onPlay: function () {
+			if ( mw.isChrome() && !this.flashActivationRequired && mw.getConfig("EmbedPlayer.EnableFlashActivation") !== false ){
+				this.flashActivationRequired = true;
+				$(".mwEmbedPlayer").hide();
+			}
 			if (this._propagateEvents) {
 				$(this).trigger("playing");
 				this.hideSpinner();
@@ -534,6 +539,10 @@
 		 * function called by flash at set interval to update the playhead.
 		 */
 		onUpdatePlayhead: function (playheadValue) {
+			if ( this.flashActivationRequired ){
+				this.flashActivationRequired = false;
+				$(".mwEmbedPlayer").show();
+			}
 			if (this.seeking) {
 				this.seeking = false;
 			}


### PR DESCRIPTION
hide the player cover layer upon play action. remove on updatePlayerEvent (as all other events trigger even when the content is blocked. Protected by a flag "EmbedPlayer.EnableFlashActivation": when set to false this feature will be turned off. Local boolean flag used to make sure this kicks-in only once