### PR TITLE
support anonymous analytics features:

### DIFF
--- a/modules/KalturaSupport/resources/mw.KAnalytics.js
+++ b/modules/KalturaSupport/resources/mw.KAnalytics.js
@@ -165,11 +165,6 @@ mw.KAnalytics.prototype = {
 				eventSet[ flashVarEvents[ fvKey ] ] = encodeURIComponent( this.embedPlayer.getKalturaConfig('statistics', fvKey ) );
 			}
 		}
-		// Use this new parameter to send hashed userId in case the partner has limitation about storing users-data on Kaltura database.
-		// This feature requires a new flashvar 'statistics.hashedUserId'.
-		if(this.embedPlayer.getKalturaConfig( 'statistics' , 'hashedUserId')){
-			eventSet.userId = this.embedPlayer.getKalturaConfig( 'statistics' , 'hashedUserId');
-		}
 		// hideUserId will remove the userId from the analytics call EVEN if the embed code sends one (unless hashedUserId is in use)
 		if(this.embedPlayer.getKalturaConfig( 'statistics' , 'hideUserId') && eventSet.userId){
 			delete(eventSet.userId);

--- a/modules/KalturaSupport/resources/mw.KAnalytics.js
+++ b/modules/KalturaSupport/resources/mw.KAnalytics.js
@@ -165,6 +165,16 @@ mw.KAnalytics.prototype = {
 				eventSet[ flashVarEvents[ fvKey ] ] = encodeURIComponent( this.embedPlayer.getKalturaConfig('statistics', fvKey ) );
 			}
 		}
+		// hideUserId will remove the userId from the analytics call EVEN if the embed code sends one (unless hashedUserId is in use)
+		if(this.embedPlayer.getKalturaConfig( 'statistics' , 'hideUserId')){
+			delete(eventSet.userId);
+		}
+		// Use this new parameter to send hashed userId in case the partner has limitation about storing users-data on Kaltura database.
+		// This feature
+		if(this.embedPlayer.getKalturaConfig( 'statistics' , 'hashedUserId')){
+			eventSet.userId = this.embedPlayer.getKalturaConfig( 'statistics' , 'hashedUserId');
+		}
+
 
 		// Add referrer parameter
 		eventSet[ 'referrer' ] = encodeURIComponent( mw.getConfig('EmbedPlayer.IframeParentUrl') );
@@ -190,7 +200,8 @@ mw.KAnalytics.prototype = {
 				// error in calling parent page event
 			}
 		}
-		if (this.embedPlayer.getFlashvars('ks')){
+		//hideKS is an attribute that will prevent the request from sending the KS even if the embed code receives one
+		if (this.embedPlayer.getFlashvars('ks') && !this.embedPlayer.getKalturaConfig( 'statistics' , 'hideKs') ){
 			eventRequest['ks'] = this.embedPlayer.getFlashvars('ks');
 		}
 

--- a/modules/KalturaSupport/resources/mw.KAnalytics.js
+++ b/modules/KalturaSupport/resources/mw.KAnalytics.js
@@ -165,14 +165,14 @@ mw.KAnalytics.prototype = {
 				eventSet[ flashVarEvents[ fvKey ] ] = encodeURIComponent( this.embedPlayer.getKalturaConfig('statistics', fvKey ) );
 			}
 		}
-		// hideUserId will remove the userId from the analytics call EVEN if the embed code sends one (unless hashedUserId is in use)
-		if(this.embedPlayer.getKalturaConfig( 'statistics' , 'hideUserId')){
-			delete(eventSet.userId);
-		}
 		// Use this new parameter to send hashed userId in case the partner has limitation about storing users-data on Kaltura database.
-		// This feature
+		// This feature requires a new flashvar 'statistics.hashedUserId'.
 		if(this.embedPlayer.getKalturaConfig( 'statistics' , 'hashedUserId')){
 			eventSet.userId = this.embedPlayer.getKalturaConfig( 'statistics' , 'hashedUserId');
+		}
+		// hideUserId will remove the userId from the analytics call EVEN if the embed code sends one (unless hashedUserId is in use)
+		if(this.embedPlayer.getKalturaConfig( 'statistics' , 'hideUserId') && eventSet.userId){
+			delete(eventSet.userId);
 		}
 
 

--- a/modules/KalturaSupport/tests/KalturaAnalytics.qunit.html
+++ b/modules/KalturaSupport/tests/KalturaAnalytics.qunit.html
@@ -96,10 +96,9 @@ kWidget.featureConfig({
 			'playbackContext': '123',
 			'originFeature': '0',
 			'applicationName': 'customAN',
-			'userId': 'customUid',
-			'hideUserId': false,
-			'hashedUserId' : "271f0ac34834141d8db75dc842a84aa390ecffa9",
-			'hideKs' : false
+			'userId': 'customUid'
+//			'hideUserId': true,
+//			'hideKs' : false
 		},
 		"chromecast":{
 			"plugin": true

--- a/modules/KalturaSupport/tests/KalturaAnalytics.qunit.html
+++ b/modules/KalturaSupport/tests/KalturaAnalytics.qunit.html
@@ -96,7 +96,10 @@ kWidget.featureConfig({
 			'playbackContext': '123',
 			'originFeature': '0',
 			'applicationName': 'customAN',
-			'userId': 'customUid'
+			'userId': 'customUid',
+			'hideUserId': false,
+			'hashedUserId' : "271f0ac34834141d8db75dc842a84aa390ecffa9",
+			'hideKs' : false
 		},
 		"chromecast":{
 			"plugin": true


### PR DESCRIPTION
hideKs: hides the KS from stats beacons even if embed-code received one
hideUserId: hides the userId from stats beacons even if embed-code received one 
