### PR TITLE
FEC-3726

### DIFF
--- a/modules/EmbedPlayer/resources/mw.FullScreenManager.js
+++ b/modules/EmbedPlayer/resources/mw.FullScreenManager.js
@@ -132,7 +132,7 @@
 				screenfull.request(fsTarget, doc);
 			};
 			// Check for native support for fullscreen and we are in an iframe server
-			if( !this.fullScreenApiExcludes() && screenfull && screenfull.enabled(doc) ) {
+			if( !this.fullScreenApiExcludes() && screenfull && screenfull.enabled(doc) && !mw.isOldAndroidChromeNativeBrowser()) {
 				callFullScreenAPI();
 			} else {
 				if(!this.fullScreenApiExcludes() && mw.isAndroidChromeNativeBrowser()){
@@ -501,7 +501,7 @@
 		},
 
 		getFsTarget: function(){
-			if( mw.getConfig('EmbedPlayer.IsIframeServer' ) && mw.getConfig('EmbedPlayer.IsFriendlyIframe') && !mw.isMobileChrome()){
+			if( (mw.getConfig('EmbedPlayer.IsIframeServer' ) && mw.getConfig('EmbedPlayer.IsFriendlyIframe')) ||  mw.isOldAndroidChromeNativeBrowser()){
 				// For desktops that supports native fullscreen api, give iframe as a target
 				var targetId;
 				if( screenfull && screenfull.enabled() ) {

--- a/modules/MwEmbedSupport/mediawiki/mediawiki.client.js
+++ b/modules/MwEmbedSupport/mediawiki/mediawiki.client.js
@@ -90,6 +90,17 @@
 	mw.isAndroidChromeNativeBrowser = function () {
 		return ( mw.isAndroid() && mw.isChrome() );
 	};
+	mw.isOldAndroidChromeNativeBrowser = function () {
+		var isAndroidMobile = userAgent.indexOf('Android') > -1 && userAgent.indexOf('Mozilla/5.0') > -1 && userAgent.indexOf('AppleWebKit') > -1;
+		var regExAppleWebKit = new RegExp(/AppleWebKit\/([\d.]+)/);
+		var resultAppleWebKitRegEx = regExAppleWebKit.exec(userAgent);
+		var appleWebKitVersion = (resultAppleWebKitRegEx === null ? null : parseFloat(regExAppleWebKit.exec(userAgent)[1]));
+		var regExChrome = new RegExp(/Chrome\/([\d.]+)/);
+		var resultChromeRegEx = regExChrome.exec(userAgent);
+		var chromeVersion = (resultChromeRegEx === null ? null : parseFloat(regExChrome.exec(userAgent)[1]));
+		var isAndroidBrowser = isAndroidMobile && (appleWebKitVersion !== null && appleWebKitVersion < 537) || (chromeVersion !== null && chromeVersion < 30);
+		return isAndroidBrowser;
+	};
 	mw.isMobileChrome = function () {
 		return ( mw.isAndroid4andUp()
 			&&

--- a/modules/MwEmbedSupport/mediawiki/mediawiki.client.js
+++ b/modules/MwEmbedSupport/mediawiki/mediawiki.client.js
@@ -91,15 +91,7 @@
 		return ( mw.isAndroid() && mw.isChrome() );
 	};
 	mw.isOldAndroidChromeNativeBrowser = function () {
-		var isAndroidMobile = userAgent.indexOf('Android') > -1 && userAgent.indexOf('Mozilla/5.0') > -1 && userAgent.indexOf('AppleWebKit') > -1;
-		var regExAppleWebKit = new RegExp(/AppleWebKit\/([\d.]+)/);
-		var resultAppleWebKitRegEx = regExAppleWebKit.exec(userAgent);
-		var appleWebKitVersion = (resultAppleWebKitRegEx === null ? null : parseFloat(regExAppleWebKit.exec(userAgent)[1]));
-		var regExChrome = new RegExp(/Chrome\/([\d.]+)/);
-		var resultChromeRegEx = regExChrome.exec(userAgent);
-		var chromeVersion = (resultChromeRegEx === null ? null : parseFloat(regExChrome.exec(userAgent)[1]));
-		var isAndroidBrowser = isAndroidMobile && (appleWebKitVersion !== null && appleWebKitVersion < 537) || (chromeVersion !== null && chromeVersion < 30);
-		return isAndroidBrowser;
+		return mw.isAndroidChromeNativeBrowser() && parseInt(userAgent.match(/Chrome\/([0-9][0-9])/)[1]) < 30;
 	};
 	mw.isMobileChrome = function () {
 		return ( mw.isAndroid4andUp()

--- a/modules/MwEmbedSupport/mediawiki/mediawiki.client.js
+++ b/modules/MwEmbedSupport/mediawiki/mediawiki.client.js
@@ -91,7 +91,11 @@
 		return ( mw.isAndroid() && mw.isChrome() );
 	};
 	mw.isOldAndroidChromeNativeBrowser = function () {
-		return mw.isAndroidChromeNativeBrowser() && parseInt(userAgent.match(/Chrome\/([0-9][0-9])/)[1]) < 30;
+		var regExpResult = userAgent.match(/Chrome\/([0-9][0-9])/);
+		if ( $.isArray( regExpResult ) && regExpResult.length > 1 ){
+			return mw.isAndroidChromeNativeBrowser() && parseInt( regExpResult[1] ) < 30;
+		}
+		return false;
 	};
 	mw.isMobileChrome = function () {
 		return ( mw.isAndroid4andUp()


### PR DESCRIPTION
detect old native chrome browsers and set proper target and fullscreen action for it. Note that old native chrome browsers fail to use the screenfull class: http://sindresorhus.com/screenfull.js/ test page doesn't work as well.

Known limitation: on old native chrome browsers, when exiting fullscreen the page zoom might not be restored properly.