### PR TITLE
SUP-4277

### DIFF
--- a/modules/EmbedPlayer/resources/mw.EmbedPlayer.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayer.js
@@ -1896,7 +1896,7 @@
 
 			// Do some device detection devices that don't support overlays
 			// and go into full screen once play is clicked:
-			if ((mw.isAndroidNativeBrowser() || mw.isIphone())) {
+			if ((mw.isAndroidNativeBrowser() || mw.isIphone()) && !mw.isWindowsPhone()) {
 				return true;
 			}
 

--- a/modules/KalturaSupport/components/largePlayBtn.js
+++ b/modules/KalturaSupport/components/largePlayBtn.js
@@ -16,8 +16,7 @@
 		 * cases where a native player is dipalyed such as iPhone.
 		 */
 		isPersistantPlayBtn: function(){
-			return mw.isAndroid2() || this.getPlayer().isLinkPlayer() || 
-					( mw.isIphone() && mw.getConfig( 'EmbedPlayer.iPhoneShowHTMLPlayScreen' ) );
+			return (mw.isAndroid2() || this.getPlayer().isLinkPlayer() || ( mw.isIphone() && mw.getConfig( 'EmbedPlayer.iPhoneShowHTMLPlayScreen' )) && !mw.isWindowsPhone() );
 		},
 		addBindings: function() {
 			var _this = this;

--- a/modules/MwEmbedSupport/mediawiki/mediawiki.client.js
+++ b/modules/MwEmbedSupport/mediawiki/mediawiki.client.js
@@ -104,7 +104,7 @@
 			)
 	};
 	mw.isWindowsPhone = function () {
-		return (  userAgent.indexOf('Windows Phone') != -1 );
+		return (  userAgent.indexOf('Windows Phone') != -1 || (userAgent.indexOf('Windows') != -1 && userAgent.indexOf('Touch') != -1));
 	};
 	mw.isIOS = function () {
 		return ( mw.isIphone() || mw.isIpod() || mw.isIpad() );


### PR DESCRIPTION
update Windows Phone detection for desktop version, don't use native player controls on Windows phone and don't use persistant play button on windows phone