### PR TITLE
Etag enhancements

### DIFF
--- a/modules/KalturaSupport/kalturaIframe.php
+++ b/modules/KalturaSupport/kalturaIframe.php
@@ -18,7 +18,7 @@ $kIframe = new kalturaIframeClass();
 if(!ob_start("ob_gzhandler")) ob_start();
 
 // Support Etag and 304
-if( $wgEnableScriptDebug == false && @trim($_SERVER['HTTP_IF_NONE_MATCH']) == $kIframe->getIframeOutputHash() ){
+if( $wgEnableScriptDebug == false && @trim($_SERVER['HTTP_IF_NONE_MATCH']) == "W/\"" . $kIframe->getIframeOutputHash() . "\"" ){
 	header("HTTP/1.1 304 Not Modified"); 
 	exit();
 } 

--- a/modules/KalturaSupport/kalturaIframeClass.php
+++ b/modules/KalturaSupport/kalturaIframeClass.php
@@ -381,7 +381,7 @@ class kalturaIframeClass {
 		}
 		// Add Etag
 		if( !$addedEtag && !$this->request->get('debug') ){
-			header("Etag: \"" . $this->getIframeOutputHash() . "\"" );
+			header("Etag: W/\"" . $this->getIframeOutputHash() . "\"" );
 		}
 	}
 

--- a/modules/KalturaSupport/kalturaIframeClass.php
+++ b/modules/KalturaSupport/kalturaIframeClass.php
@@ -381,7 +381,7 @@ class kalturaIframeClass {
 		}
 		// Add Etag
 		if( !$addedEtag && !$this->request->get('debug') ){
-			header("Etag: " . $this->getIframeOutputHash() );
+			header("Etag: \"" . $this->getIframeOutputHash() . "\"" );
 		}
 	}
 

--- a/mwEmbedLoader.php
+++ b/mwEmbedLoader.php
@@ -96,7 +96,7 @@ class mwEmbedLoader {
 		}
 		
 		// Support Etag and 304
-		if( $wgEnableScriptDebug == false && @trim($_SERVER['HTTP_IF_NONE_MATCH']) == $this->getOutputHash( $o ) ){
+		if( $wgEnableScriptDebug == false && @trim($_SERVER['HTTP_IF_NONE_MATCH']) == "W/\"" . $this->getOutputHash( $o ) . "\"" ){
 			header("HTTP/1.1 304 Not Modified");
 			exit();
 		}
@@ -459,7 +459,7 @@ class mwEmbedLoader {
 	private function sendHeaders( $o ){
 		global $wgEnableScriptDebug;
 		
-		header("Etag: \"" . $this->getOutputHash( $o ) . "\"" );
+		header("Etag: W/\"" . $this->getOutputHash( $o ) . "\"" );
 		header("Content-Type: text/javascript");
 		if( isset( $_GET['debug'] ) || $wgEnableScriptDebug ){
 			header("Cache-Control: no-cache, must-revalidate"); // HTTP/1.1

--- a/mwEmbedLoader.php
+++ b/mwEmbedLoader.php
@@ -459,7 +459,7 @@ class mwEmbedLoader {
 	private function sendHeaders( $o ){
 		global $wgEnableScriptDebug;
 		
-		header("Etag: " . $this->getOutputHash( $o ) );
+		header("Etag: \"" . $this->getOutputHash( $o ) . "\"" );
 		header("Content-Type: text/javascript");
 		if( isset( $_GET['debug'] ) || $wgEnableScriptDebug ){
 			header("Cache-Control: no-cache, must-revalidate"); // HTTP/1.1


### PR DESCRIPTION
This patch fixes CDN caching problem if CDN support 'Vary: Accept-Encoding'.

Apache deflates response body if clients set Accept-Encoding and Apache doesn't rewrite ETag header because backend generates that. So deflated response and non-deflated response has same ETag. it happened that CDN servers always return deflated response even if client has no Accept-Encoding.
Weakness indicator is used in this situation. See also RFC7232 section 2.3
