### PR TITLE
#SUP-5481 #comment enable control bar for audio player native #time 2h

### DIFF
--- a/modules/KalturaSupport/components/controlBarContainer.js
+++ b/modules/KalturaSupport/components/controlBarContainer.js
@@ -9,8 +9,8 @@
 		keepOnScreen: false,
 
 		setup: function(){
-			// Exit if we're using native controls
-			if( this.getPlayer().useNativePlayerControls() ) {
+			// Exit if we're using native controls, and is not audio player
+			if( this.getPlayer().useNativePlayerControls() && !this.getPlayer().isAudioPlayer ) {
 				this.getPlayer().enableNativeControls();
 				return;
 			}

--- a/modules/KalturaSupport/resources/mw.KWidgetSupport.js
+++ b/modules/KalturaSupport/resources/mw.KWidgetSupport.js
@@ -137,7 +137,6 @@ mw.KWidgetSupport.prototype = {
 			}
 			var alt = gM('mwe-embedplayer-video-thumbnail-for', embedPlayer.evaluate('{mediaProxy.entry.name}'));
 			embedPlayer.updatePoster( thumbUrl, alt );
-			embedPlayer.isAudioPlayer = ( embedPlayer.kalturaPlayerMetaData.mediaType === 5 );
 		});
 
 		// Add black sources:
@@ -253,6 +252,8 @@ mw.KWidgetSupport.prototype = {
 		}
 		// Check for "image" mediaType ( 2 )
 		this.updateImagePlayerData(embedPlayer, playerData);
+		// Check for "audio" mediaType ( 5 )
+		this.updateAudioPlayerData(embedPlayer, playerData);
 		// Check for external media:
 		this.updateExternalPlayerData(embedPlayer, playerData);
 		// check for entry id not found:
@@ -468,6 +469,9 @@ mw.KWidgetSupport.prototype = {
 					.get( 0 )
 			);
 		}
+	},
+	updateAudioPlayerData: function(embedPlayer, playerData){
+		embedPlayer.isAudioPlayer = playerData.meta.mediaType === 5;
 	},
 	updateExternalPlayerData: function(embedPlayer, playerData){
 		// Check for external media:

--- a/modules/KalturaSupport/tests/AudioEntryPlayer.qunit.html
+++ b/modules/KalturaSupport/tests/AudioEntryPlayer.qunit.html
@@ -36,7 +36,7 @@
 	Highlights an audio only player, disables large play button. 
 	
 	<br />
-	<div id="kaltura_player" style="width:400px;height:30px;"></div>
+	<div id="kaltura_player" style="width:400px;height:28px;"></div>
 	<script>
 		kWidget.featureConfig({
 			'targetId' : 'kaltura_player',


### PR DESCRIPTION
- Enabled control bar for native audio player.
- Check if isAudioPlayer player when you load and update player data.
- Fix audio player test page height.
