### PR TITLE
Fixed creativedata being empty

### DIFF
--- a/modules/KalturaSupport/resources/mw.KAdPlayer.js
+++ b/modules/KalturaSupport/resources/mw.KAdPlayer.js
@@ -1340,7 +1340,7 @@ mw.KAdPlayer.prototype = {
 		var _this = this;
 		var VPAIDObj = null;
 		var vpaidId = this.getVPAIDId();
-		var creativeData = {};
+		var creativeData = { 'AdParameters': adConf.adParameters };
 		var environmentVars = {
 			slot: _this.embedPlayer.getVideoHolder().get(0),
 			videoSlot:  _this.embedPlayer.getPlayerElement(),


### PR DESCRIPTION
creativedata it's not handling the AdParameters element from VAST XML which results in interactive pre-rolls not working.