### PR TITLE
Allow setting EmbedPlayer.WebKitPlaysInline

### DIFF
--- a/modules/KalturaSupport/kalturaIframeClass.php
+++ b/modules/KalturaSupport/kalturaIframeClass.php
@@ -177,6 +177,9 @@ class kalturaIframeClass {
 		if( isset( $playerConfig['vars']['EmbedPlayer.WebKitAllowAirplay'] ) ){
 			$o.= 'x-webkit-airplay="allow" ';
 		}
+		if( isset( $playerConfig['vars']['EmbedPlayer.WebKitPlaysInline'] ) ){
+			$o.= 'webkit-playsinline ';
+		}
 
 		// Add any additional attributes:
 		foreach( $videoTagMap as $key => $val ){


### PR DESCRIPTION
Setting EmbedPlayer.WebKitPlaysInline does not work, please see my issue #2041

In the [docs](http://player.kaltura.com/docs/api#EmbedPlayer.WebKitPlaysInline) this variable is mentioned, but setting the variable currently does nothing.