### PR TITLE
Fix for FEC-3965

### DIFF
--- a/modules/KalturaSupport/components/sourceSelector.js
+++ b/modules/KalturaSupport/components/sourceSelector.js
@@ -244,8 +244,7 @@
             }
 
             //HLS, HDS
-
-            if (this.getPlayer().streamerType !== "http" && mw.isNativeApp()) {
+            if (mw.isNativeApp()) {
             	this.sourcesList = [];
                 this.addAutoToMenu();
                 return true;


### PR DESCRIPTION
The stream is detected as http instead of hls, which causes the source selector not to add flavors to menu.