### PR TITLE
FEC-3717 #comment Lazy load source on IE

### DIFF
--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
@@ -125,7 +125,7 @@
 				this.supports.volumeControl = false;
 			}
 			// Check if we already have a selected source and a player in the page,
-			if (this.getPlayerElement() && this.getSrc()) {
+			if (this.getPlayerElement() && this.getSrc() && !mw.isIE()) {
 				$(this.getPlayerElement()).attr('src', this.getSrc());
 			}
 			// Check if we already have a video element an apply bindings ( for native interfaces )
@@ -301,7 +301,7 @@
 				return;
 			}
 			// Update the player source ( if needed )
-			if ($(vid).attr('src') != this.getSrc(this.currentTime)) {
+			if ($(vid).attr('src') != this.getSrc(this.currentTime) && !mw.isIE()) {
 				$(vid).attr('src', this.getSrc(this.currentTime));
 			}
 


### PR DESCRIPTION
IE ignores preload attribute and loads the source, don’t set the src
attribute until the user issues a play command.
The doPlay function will take care of the source loading.