### PR TITLE
SUP-5573 #comment Fix native player changeMedia flow

### DIFF
--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
@@ -193,9 +193,6 @@
 					}
 					_this.updatePosterHTML();
 				}
-				if (!(mw.isIOS7() && mw.isIphone())) {
-					_this.changeMediaCallback = null;
-				}
 				callback();
 			});
 		},


### PR DESCRIPTION
Don’t delete the callback function after first changeMedia, as it cuts
the flow for next changeMedia calls which also effects the seek logic.
The change was tested against PS-1861 ticket which was the reason for
the code that was now deleted and everything seems to work properly
with related/playlists/doublclick changeMedia on iPhone and iPad ios7/8