### PR TITLE
fix playlist item bad width (TR-331)

### DIFF
--- a/modules/KalturaSupport/components/playlistAPI.js
+++ b/modules/KalturaSupport/components/playlistAPI.js
@@ -283,6 +283,7 @@
 						_this.playlistSet[_this.currentPlaylistIndex].name = params.playlistName; //apply data to the correct playlist in the playlistSet
 					}
 					_this.selectPlaylist(_this.currentPlaylistIndex);
+					_this.redrawPlaylist();
 					_this.currentClipIndex = -1; //reset index of current clip so "next" will play the first item of the new loaded playlist
 					if(params.autoInsert){
 						_this.playNext();


### PR DESCRIPTION
the description below is related to TR-331:

If the empty playlist error happened, mw.KBaseMediaList.js sets config MinClips to zero (because playlist is empty).
Then, when switching to "Player mode”, redrawPlaylist function is called, and here: https://github.com/kaltura/mwEmbed/blob/5d9e19ee5fff0ad23b595b6a6a508676cdf59856/modules/KalturaSupport/components/playlistAPI.js#L312 when updating mediaItemWidth division-by-zero takes place, so mediaItemWidth now equals Infinity, so all other math operations are screwed up and all this results in the TR-331.