### PR TITLE
Fix Youtube play list on mobile getting stuck with disabled player when switching entries

### DIFF
--- a/modules/ExternalPlayers/resources/mw.EmbedPlayerYouTube.js
+++ b/modules/ExternalPlayers/resources/mw.EmbedPlayerYouTube.js
@@ -375,7 +375,7 @@
 
 			this.bindHelper ('playerReady' + this.bindPostfix , function(){
 				$('.playerPoster').before('<div class="blackBoxHide" style="width:100%;height:100%;background:black;position:absolute;"></div>');
-				if (mw.isMobileDevice()){
+				if (!_this.canAutoPlay()){
 					_this._playContorls = false;
 					$( _this ).trigger( 'onDisableInterfaceComponents', [["playlistAPI"]] );
 				}


### PR DESCRIPTION
for youtube - disable player controls only if the player cannot autoplay