### PR TITLE
Passing through ajaxOptions for Wrapped Vast Feeds

### DIFF
--- a/modules/AdSupport/resources/mw.AdLoader.js
+++ b/modules/AdSupport/resources/mw.AdLoader.js
@@ -51,7 +51,7 @@ mw.AdLoader = {
 			url: adUrl,
 			ajaxOptions: ajaxOptions,
 			success: function( resultXML ) {
-				_this.handleResult( resultXML, callback );
+				_this.handleResult( resultXML, callback, ajaxOptions );
 			},
 			error: function( error ) {
 				mw.log("Error: AdLoader failed to load:" + adUrl);
@@ -59,7 +59,7 @@ mw.AdLoader = {
 			}
 		});
 	},
-	handleResult: function(data, callback ){
+	handleResult: function(data, callback, ajaxOptions ){
 		var _this = this;
 		// If our data is a string we need to parse it as XML
 		if( typeof data === 'string' ) {
@@ -80,7 +80,7 @@ mw.AdLoader = {
 				// If we have lots of ad formats we could conditionally load them here:
 				// 'mw.VastAdParser' is a dependency of adLoader
 				mw.load( 'mw.VastAdParser', function(){
-					mw.VastAdParser.parse( data, callback , _this.wrapperData);
+					mw.VastAdParser.parse( data, callback , _this.wrapperData, ajaxOptions );
 				});
 				return ;
 			break;

--- a/modules/AdSupport/resources/mw.VastAdParser.js
+++ b/modules/AdSupport/resources/mw.VastAdParser.js
@@ -12,7 +12,7 @@ mw.VastAdParser = {
 	 * VAST support
 	 * Convert the vast ad display format into a display conf:
 	 */
-	parse: function( xmlObject, callback , wrapperData ){
+	parse: function( xmlObject, callback , wrapperData, originalAjaxOptions ){
 		var _this = this;
         // in case there is a wrapper for this ad - keep the data so we will be able to track the wrapper events later
         this.wrapperData = null;
@@ -33,7 +33,7 @@ mw.VastAdParser = {
 			var adUrl = $vast.find('VASTAdTagURI').text();
 			addVideoClicksIfExist();
 			mw.log('VastAdParser:: Found vast wrapper, load ad: ' + adUrl);
-			mw.AdLoader.load( adUrl, callback, true , $vast, null );
+			mw.AdLoader.load( adUrl, callback, true , $vast, originalAjaxOptions );
 			return ;
 		}
 


### PR DESCRIPTION
ajaxOptions (i.e. enableCORS) are only used for the first vast feed in a request chain. If the vast response contains a Wrapper ad stating to download another vast URL, the enableCORS option is not utilized in that secondary request. Without these options, the initial request might have enableCORS set to true and be able to set permanent cookies, but secondary requests are unable to store permanent cookies.

There is only one global enableCORS config setting, it should be used on all requests.

Fix by passing through the ajaxOptions used in the initial request into the mw.VastAdParser.parse function so that they can be used in secondary vast URL requests initiated from within.