### PR TITLE
Allowing Impressions from multiple vast wrappers

### DIFF
--- a/modules/AdSupport/resources/mw.AdLoader.js
+++ b/modules/AdSupport/resources/mw.AdLoader.js
@@ -14,15 +14,17 @@ mw.AdLoader = {
 	 * 		Function called with ad payload once ad content is loaded.
 	 * @param {boolean} wrapped
 	 * 		(optional) used to increase the internal counter
-	 * @param {XML} wrapperData
-	 * 		(optional) in case this loader is being called from a wrapper, preserve the wrapper data and pass it to the
-     * 		inner ad so it can parse and send its events
+	 * @param {array} wrapperData
+	 * 		(optional) in case this loader is being after loading a wrapper, preserve all previous wrapper data and pass it to the
+	 * 		inner ad so it can parse and send all events
 	 * @param {object} ajaxOptions
 	 * 		(optional) additional ajax options, e.g. withCredentials
 	 */
 	load: function( adUrl, callback, wrapped , wrapperData, ajaxOptions ){
 		var _this = this;
-        this.wrapperData = null;
+		if(wrapperData == null) {
+			wrapperData = [];
+		}
 
 		adUrl = _this.replaceCacheBuster(adUrl);
 		
@@ -33,7 +35,6 @@ mw.AdLoader = {
 
 		// Increase counter if the vast is wrapped, otherwise reset
 		if( wrapped ) {
-            this.wrapperData = wrapperData ;
 			this.currentCounter++;
 		} else {
 			this.currentCounter = 0;
@@ -51,7 +52,7 @@ mw.AdLoader = {
 			url: adUrl,
 			ajaxOptions: ajaxOptions,
 			success: function( resultXML ) {
-				_this.handleResult( resultXML, callback, ajaxOptions );
+				_this.handleResult( resultXML, callback, wrapperData, ajaxOptions );
 			},
 			error: function( error ) {
 				mw.log("Error: AdLoader failed to load:" + adUrl);
@@ -59,7 +60,7 @@ mw.AdLoader = {
 			}
 		});
 	},
-	handleResult: function(data, callback, ajaxOptions ){
+	handleResult: function(data, callback, wrapperData, ajaxOptions ){
 		var _this = this;
 		// If our data is a string we need to parse it as XML
 		if( typeof data === 'string' ) {
@@ -80,7 +81,7 @@ mw.AdLoader = {
 				// If we have lots of ad formats we could conditionally load them here:
 				// 'mw.VastAdParser' is a dependency of adLoader
 				mw.load( 'mw.VastAdParser', function(){
-					mw.VastAdParser.parse( data, callback , _this.wrapperData, ajaxOptions );
+					mw.VastAdParser.parse( data, callback , wrapperData, ajaxOptions );
 				});
 				return ;
 			break;

--- a/modules/AdSupport/resources/mw.VastAdParser.js
+++ b/modules/AdSupport/resources/mw.VastAdParser.js
@@ -15,9 +15,8 @@ mw.VastAdParser = {
 	parse: function( xmlObject, callback , wrapperData, originalAjaxOptions ){
 		var _this = this;
 		// in case there is a wrapper for this ad - keep the data so we will be able to track the wrapper events later
-		this.wrapperData = null;
-		if(wrapperData){
-			this.wrapperData = wrapperData;
+		if (wrapperData == null) {
+			wrapperData = [];
 		}
 		var adConf = {};
 		var $vast = $( xmlObject );
@@ -30,15 +29,17 @@ mw.VastAdParser = {
 
 		// Check for Vast Wrapper response
 		if( $vast.find('Wrapper').length && $vast.find('VASTAdTagURI').length) {
+			wrapperData.push($vast);
 			var adUrl = $vast.find('VASTAdTagURI').text();
 			addVideoClicksIfExist();
 			mw.log('VastAdParser:: Found vast wrapper, load ad: ' + adUrl);
-			mw.AdLoader.load( adUrl, callback, true , $vast, originalAjaxOptions );
+			mw.AdLoader.load( adUrl, callback, true , wrapperData, originalAjaxOptions );
 			return ;
 		}
 
 
 		// Get the basic set of sequences
+		this.wrapperData = wrapperData;
 		adConf.ads = [];
 		$vast.find( 'Ad' ).each( function( inx, node ){
 		//	mw.log( 'VastAdParser:: getVastAdDisplayConf: ' + node );
@@ -115,26 +116,29 @@ mw.VastAdParser = {
 			});
 
 			//handle wrapper events if exists
-			if(_this.wrapperData){
+			if ( _this.wrapperData.length > 0 ) {
+				for ( var i = 0, iMax = _this.wrapperData.length; i < iMax; i++ ) {
+					var wrapperData = _this.wrapperData[i];
 
-				//impression of wrapper:
-				var $impressionWrapper = $(_this.wrapperData).contents().find('Wrapper Impression');
-				if($impressionWrapper.length){
-					$impressionWrapper.each( function( na, trackingNode ){
-						currentAd.impressions.unshift({
-							'beaconUrl' : $(trackingNode).text()
+					//impression of wrapper:
+					var $impressionWrapper = $(wrapperData).contents().find('Wrapper Impression');
+					if($impressionWrapper.length){
+						$impressionWrapper.each( function( na, trackingNode ){
+							currentAd.impressions.unshift({
+								'beaconUrl' : $(trackingNode).text()
+							});
 						});
-					});
-				}
-				//events
-				var $wrapperEvents = $(_this.wrapperData).contents().find('Wrapper Creatives TrackingEvents Tracking');
-				if($wrapperEvents.length){
-					$wrapperEvents.each( function( na, trackingNode ){
-						currentAd.trackingEvents.push({
-							'eventName' : $( trackingNode ).attr('event'),
-							'beaconUrl' : _this.getURLFromNode( trackingNode )
+					}
+					//events
+					var $wrapperEvents = $(wrapperData).contents().find('Wrapper Creatives TrackingEvents Tracking');
+					if($wrapperEvents.length){
+						$wrapperEvents.each( function( na, trackingNode ){
+							currentAd.trackingEvents.push({
+								'eventName' : $( trackingNode ).attr('event'),
+								'beaconUrl' : _this.getURLFromNode( trackingNode )
+							});
 						});
-					});
+					}
 				}
 			}
 
@@ -255,7 +259,7 @@ mw.VastAdParser = {
 		if (_this.videoClickTrackingUrl != undefined){
 			adConf.videoClickTracking.push(_this.videoClickTrackingUrl);
 		}
-		adConf.wrapperData = _this.wrapperData;
+		adConf.wrapperData = wrapperData;
 		// Run callback we adConf data
 		callback( adConf );
 	},

--- a/modules/KalturaSupport/resources/mw.KAdPlayer.js
+++ b/modules/KalturaSupport/resources/mw.KAdPlayer.js
@@ -543,11 +543,13 @@ mw.KAdPlayer.prototype = {
 				mw.sendBeaconUrl( adSlot.videoClickTracking [i]);
 			}
 			//handle wrapper clickTracking
-			if(adSlot.wrapperData ){
-				adSlot.wrapperData.contents().find('ClickTracking').each(function(a,b){
-					mw.sendBeaconUrl($(b).contents().text());
-					mw.log("KAdPlayer:: sendBeacon to (wrapper): " + $(b).contents().text() );
-				})
+			if( adSlot.wrapperData && adSlot.wrapperData.length > 0 ){
+				for ( var i = 0, iMax = adSlot.wrapperData.length; i < iMax; i++) {
+					adSlot.wrapperData[i].contents().find('ClickTracking').each(function(a,b){
+						mw.sendBeaconUrl($(b).contents().text());
+						mw.log("KAdPlayer:: sendBeacon to (wrapper): " + $(b).contents().text() );
+					})
+				}
 			}
 		}
 		window.open( clickthrough );


### PR DESCRIPTION
(Re-opened from https://github.com/kaltura/mwEmbed/pull/2167 to fix line endings)

If a vast request chain results in more than one wrapper ad, e.g.

wrapper 1 -> wrapper 2 -> ad

then tracking impressions found on all wrappers mut be sent when the main ad's tracking URLs are called.

But currently only tracking urls found on the final wrapper (e.g. wrapper 2) are being called. This is because the wrapperData variable is cleared each time the mw.VastAdParser.parse function is called, but the function has to be called for each vast response.

Fix - Instead of storing only the last wrapperData, store all previous wrapperData objects in an array, and when setting up tracking URL-calling functionality, loop over all stored wrapperData objects and call each object's respective tracking URLs, not just those in the final wrapper.