### PR TITLE
fix Stack Overflow in IE8 when changing media (TR-272)

### DIFF
--- a/modules/EmbedPlayer/resources/mw.EmbedPlayer.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayer.js
@@ -1677,7 +1677,9 @@
 			}
 
 			// Add a loader to the embed player:
-			this.pauseLoading();
+			this.isPauseLoading = true;
+			this.pause();
+			this.addPlayerSpinner();
 
 			// Stop the monitor
 			this.stopMonitor();


### PR DESCRIPTION
May happen because IE8 has call stack limited to 12 frames (function calls)