### PR TITLE
Correcting flash VPAID dimensions

### DIFF
--- a/modules/KalturaSupport/resources/mw.KAdPlayer.js
+++ b/modules/KalturaSupport/resources/mw.KAdPlayer.js
@@ -1610,10 +1610,9 @@ mw.KAdPlayer.prototype = {
 				if ( adConf.adParameters ) {
 					playerParams.vpaidAdParameters = escape( adConf.adParameters );
 				}
-				if ( adConf.vpaid.flash.width ) {
-					playerParams.vpaidAdWidth = adConf.vpaid.flash.width;
-					playerParams.vpaidAdHeight = adConf.vpaid.flash.height;
-				}
+				playerParams.vpaidAdWidth = _this.embedPlayer.getWidth();
+				playerParams.vpaidAdHeight = _this.embedPlayer.getVideoHolder().height();
+
 				//flashvars to load vpaidPlugin.swf and to disable on screen clicks since vpaid swf will handle the clicks
 				var adSibling = new mw.PlayerElementFlash( vpaidId, vpaidId + "_obj", playerParams, null, function () {
 					VPAIDObj = this.getElement();


### PR DESCRIPTION
The VPAID spec indicates for the `initAd()` function we need to pass a width and height into the unit.  The values here describe the __available ad display area__.

For VPAID 2.0:
> 3.1.2 initAd()
> width: indicates the available ad display area width in pixels
> height: indicates the available ad display area height in pixels

For VPAID 1.0:
> 4.7.2 initAd()
> The player passes a width and height to indicate the display area for the ad.

When working with a JavaScript VPAID unit, the `initAd()` function is correctly called with using the embedPlayer width and videoHolder height:

```javascript
VPAIDObj.initAd( _this.embedPlayer.getWidth(), _this.embedPlayer.getVideoHolder().height(), 'normal', 512, creativeData, environmentVars );
```

However flash is different.  The `initAd()` Function is called from within the vpaidPlugin.swf.  The values it uses are supplied in the vpaidAdWidth and vpaidAdHeight flashvars parameters.  These parameters are populated with the values read from the `<Media>` element in the vast feed where the VPAID swf is contained.

Some advertisers are specifying small width and height values in this `<Media>` element, and this incorrectly renders a small size ad instead of maximizing to the video area.

Fix: Change the width and height of the video display area passed to the flash swf to be the same as what would be used for a JavaScript VPAID ad instead of the VAST feed's `<Media>` element attribute values.