### PR TITLE
FEC-4191

### DIFF
--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerImageOverlay.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerImageOverlay.js
@@ -207,9 +207,6 @@
 				mw.log( "EmbedPlayerImageOverlay:: playerSwitchSource, embedPlayerHTML callback" );
 				_this.applyIntrinsicAspect();
 				_this.play();
-				if( switchCallback ){
-					switchCallback( _this );
-				}
 				// Wait for ended event to trigger
 				$( _this ).bind( 'ended.playerSwitchSource', function(){
 					_this.stopMonitor();
@@ -219,6 +216,9 @@
 					}
 				});
 			});
+			if( switchCallback ){
+				switchCallback( this );
+			}
 		},
 		/** issue a load call on native element, so we can play it in the future */
 		captureUserGesture: function(){


### PR DESCRIPTION
fire switch source callback after calling switch source instead of waiting for the image to finish loading (sometimes we don't get the image loaded event)