### PR TITLE
Allow Vast Wrapper URLs to work with Kaltura Ad Tag Substitutions

### DIFF
--- a/modules/AdSupport/resources/mw.AdLoader.js
+++ b/modules/AdSupport/resources/mw.AdLoader.js
@@ -1,10 +1,21 @@
 ( function( mw, $ ) { "use strict";
 
-mw.AdLoader = {
+mw.AdLoader = function( embedPlayer ) {
+	// Create an AdLoader
+	return this.init( embedPlayer );
+};
+
+mw.AdLoader.prototype = {
+
 	// Vast response can return Wrapper that points to another vast
 	// this varible holds the max number of redirects to follow
 	maxRedirects: 5,
 	currentCounter: 0,
+
+	init: function( embedPlayer ){
+		this.embedPlayer = embedPlayer;
+	},
+
 	/**
 	 * Get ad display configuration object from a url
 	 *
@@ -81,7 +92,7 @@ mw.AdLoader = {
 				// If we have lots of ad formats we could conditionally load them here:
 				// 'mw.VastAdParser' is a dependency of adLoader
 				mw.load( 'mw.VastAdParser', function(){
-					mw.VastAdParser.parse( data, callback , wrapperData, ajaxOptions );
+					mw.VastAdParser.parse( data, callback , wrapperData, ajaxOptions, _this );
 				});
 				return ;
 			break;

--- a/modules/AdSupport/resources/mw.VastAdParser.js
+++ b/modules/AdSupport/resources/mw.VastAdParser.js
@@ -12,7 +12,7 @@ mw.VastAdParser = {
 	 * VAST support
 	 * Convert the vast ad display format into a display conf:
 	 */
-	parse: function( xmlObject, callback , wrapperData, originalAjaxOptions ){
+	parse: function( xmlObject, callback , wrapperData, originalAjaxOptions, adLoader ){
 		var _this = this;
 		// in case there is a wrapper for this ad - keep the data so we will be able to track the wrapper events later
 		if (wrapperData == null) {
@@ -31,9 +31,10 @@ mw.VastAdParser = {
 		if( $vast.find('Wrapper').length && $vast.find('VASTAdTagURI').length) {
 			wrapperData.push($vast);
 			var adUrl = $vast.find('VASTAdTagURI').text();
+			adUrl=adLoader.embedPlayer.evaluate(adUrl);
 			addVideoClicksIfExist();
 			mw.log('VastAdParser:: Found vast wrapper, load ad: ' + adUrl);
-			mw.AdLoader.load( adUrl, callback, true , wrapperData, originalAjaxOptions );
+			adLoader.load( adUrl, callback, true , wrapperData, originalAjaxOptions );
 			return ;
 		}
 

--- a/modules/KalturaSupport/resources/mw.KAds.js
+++ b/modules/KalturaSupport/resources/mw.KAds.js
@@ -38,6 +38,9 @@
 
 			_this.embedPlayer = embedPlayer;
 
+			// Setup the ad loader:
+			_this.adLoader = new mw.AdLoader( embedPlayer );
+
 			// Setup the ad player:
 			_this.adPlayer = new mw.KAdPlayer( embedPlayer );
 
@@ -193,7 +196,7 @@
 				return ;
 			}
 			// Load Ad
-			mw.AdLoader.load( cuePoint.sourceUrl, function( adConf ){
+			_this.adLoader.load( cuePoint.sourceUrl, function( adConf ){
 				if( ! adConf ) {
 					return ;
 				}
@@ -264,7 +267,7 @@
 
 			var baseDisplayConf = this.getBaseDisplayConf();
 
-			mw.AdLoader.load( cuePoint.sourceUrl, function( adConf ){
+			_this.adLoader.load( cuePoint.sourceUrl, function( adConf ){
 				// No Ad configuration, continue playback
 				if( ! adConf ){
 					// Ad skip re-enable play controls:
@@ -480,7 +483,7 @@
 					// Disable UI while playing ad
 					_this.embedPlayer.adTimeline.updateUiForAdPlayback( adType );
 
-					mw.AdLoader.load( _this.getAdUrl( adType ), function( adDisplayConf ){
+					_this.adLoader.load( _this.getAdUrl( adType ), function( adDisplayConf ){
 						var adConf = $.extend(adConfig, _this.getBaseAdConf( adType ), adDisplayConf );
 						_this.adPlayer.display( adConf, function(){
 							// play next ad
@@ -624,7 +627,7 @@
 				if( _this.getConfig( adType + 'Url' ) ){
 					loadQueueCount++;
 					// Load and parse the adXML into displayConf format
-					mw.AdLoader.load( _this.getAdUrl( adType ) , function( adDisplayConf ){
+					_this.adLoader.load( _this.getAdUrl( adType ) , function( adDisplayConf ){
 						mw.log("KalturaAds loaded: " + adType );
 						loadQueueCount--;
 						addAdCheckLoadDone( adType,  $.extend({}, _this.getBaseAdConf( adType ), adDisplayConf ));


### PR DESCRIPTION
The Kaltura player allows string-substitution on the ad URL:
(see http://knowledge.kaltura.com/integrating-kaltura-vast-adtag-url)

If that ad url is a vast wrapper feed, it will contain another URL that should be requested and followed.  But there is no substitution that occurs on these subsequent wrapper vast feeds, meaning each original request also has to contain all parameters for subsequent feed request.

Instead, it will be more useful to allow the same string substitution on Wrapper URLs, so that previous URLs in the vast request chain do not have to pass along all information, and can take better advantage of caching.

Fix: 

Instead of declaring `mw.AdLoader` as a static object, allow it to be initalized similar to `mw.KAdPlayer` - making the object a function where the `embedPlayer` variable is provided, then creating an `init` function on it's `prototype` to store the `embedPlayer` variable so that it can be set and accessed from within it, allowing creation of an instance of an AdLoader (from mw.KAds.js).

Modify the `VastParser` static object to include the `mw.AdLoader` object that is calling it as an argument in the `parse` function, facilitating access to the `embedPlayer` variable from the VastParser object.

Once the `embedPlayer` variable is available from within the `VastParser`, we can call it's 'evaluate' function (which is used in KAds.js on the original URL) on any VastAdTagURI, and perform any string substitutions in the same way as for the original feed URL.