### PR TITLE
#SUP-6057 #comment remove width/height IE issue #time 2h

### DIFF
--- a/modules/KalturaSupport/components/logo.js
+++ b/modules/KalturaSupport/components/logo.js
@@ -22,7 +22,7 @@
 						.attr({
 							alt: this.getConfig('title'),
 							src: this.getConfig('img')
-						});
+						}).removeAttr("width height");
 				}
 				this.$el = $('<div />')
 					.addClass(this.getCssClass())


### PR DESCRIPTION
In IE 10/9 width height added, seems like jquery added them to fix aspect ratios.
You can still set width/height using css if required.