### PR TITLE
FEC-4297

### DIFF
--- a/modules/DoubleClick/resources/mw.DoubleClick.js
+++ b/modules/DoubleClick/resources/mw.DoubleClick.js
@@ -1145,6 +1145,7 @@
 
 			this.embedPlayer.getPlayerElement().subscribe(function(adInfo){
 				mw.log("DoubleClick:: adStart");
+				_this.embedPlayer.sequenceProxy.isInSequence = true;
 				// set volume when ad starts to enable autoMute. TODO: remove next line once DoubleClick fix their bug when setting adsManager.volume before ad starts
 				_this.embedPlayer.setPlayerElementVolume(_this.embedPlayer.volume);
 				// trigger ad play event
@@ -1276,7 +1277,6 @@
 			this.embedPlayer.getPlayerElement().subscribe(function(adInfo){
 				mw.log("DoubleClick:: contentPauseRequested");
 				_this.entryDuration = _this.embedPlayer.getDuration();
-				_this.embedPlayer.sequenceProxy.isInSequence = true;
 				_this.embedPlayer.stopMonitor();
 				_this.playingLinearAd = true;
 			},'contentPauseRequested', true);


### PR DESCRIPTION
set isInSequence to true upon adStart events instead of contentPauseRequested event in chromeless (same logic as JS)