### PR TITLE
FEC-4394 #comment Resume event propagation after canSeek check

### DIFF
--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
@@ -437,9 +437,11 @@
 				// if on the first call ( and video not ready issue load, play
 				if (callbackCount == 0 && vid.paused) {
 					this.stopEventPropagation();
+					this.isWaitingForSeekReady = true;
 					var vidObj = $(vid);
 					var eventName = mw.isIOS() ? "canplaythrough.seekPrePlay" : "canplay.seekPrePlay";
 					vidObj.off(eventName).one(eventName, function () {
+						_this.isWaitingForSeekReady = false;
 						_this.restoreEventPropagation();
 						if (vid.duration > 0) {
 							_this.log("player can seek");
@@ -473,6 +475,10 @@
 			} else {
 				setTimeout(function(){
 					_this.log("player can seek");
+					if (_this.isWaitingForSeekReady){
+						_this.restoreEventPropagation();
+						_this.isWaitingForSeekReady = false;
+					}
 					return checkVideoStateDeferred.resolve();
 				}, 10);
 			}


### PR DESCRIPTION
Only in case readyForVideo check is in motion, so we mask the event
propagation, so this is to ensure that other check will resume the
event propagation if they are reached before.