### PR TITLE
FEC-4433 Added new API service: getLicenseData.

### DIFF
--- a/includes/DefaultSettings.php
+++ b/includes/DefaultSettings.php
@@ -272,6 +272,7 @@ include_once( realpath( dirname( __FILE__ ) )  . '/../modules/KalturaSupport/api
 include_once( realpath( dirname( __FILE__ ) )  . '/../modules/KalturaSupport/apiServices/mweFeaturesList.php' );
 include_once( realpath( dirname( __FILE__ ) )  . '/../modules/KalturaSupport/apiServices/mweApiLanguageSupport.php' );
 include_once( realpath( dirname( __FILE__ ) )  . '/../modules/KalturaSupport/apiServices/mweUpgradePlayer.php' );
+include_once( realpath( dirname( __FILE__ ) )  . '/../modules/KalturaSupport/apiServices/mweApiGetLicenseData.php' );
 include_once( realpath( dirname( __FILE__ ) )  . '/../studio/studioService.php');
 /**
  * Extensions should register foreign module sources here. 'local' is a

--- a/modules/KalturaSupport/apiServices/mweApiGetLicenseData.php
+++ b/modules/KalturaSupport/apiServices/mweApiGetLicenseData.php
@@ -15,50 +15,88 @@
 		},
 		"licenseServerBaseURL": "https://drm.example.com/license"
 	}
+	
+	OR, if there's an error:
+	{
+		"error": {
+			"message": "something is wrong"
+		}
+	}
 */
 
 
 $wgMwEmbedApiServices['getLicenseData'] = 'mweApiGetLicenseData';
 
-require_once( dirname( __FILE__ ) . '/../KalturaCommon.php' );
+require_once( dirname( __FILE__ ) . '/../KalturaCommon.php' );	// For EntryResult
 
 class mweApiGetLicenseData {
 
-	function run() {
-		global $wgKalturaUdrmLicenseServerUrl;
-
-		$flavorData = $this->getData();
-
-		$this->sendHeaders();
-		
-		if (!$flavorData) {
-			echo "{}";
-			return;
-		}
-		
-		// Filter by flavor_ids, if specified.
+	function __construct() {
+		global $container;
+	}
+	
+	function filterByRequestedFlavors($fullFlavorData) {
 		$flavorIds = $_REQUEST["flavor_ids"];
-		
-		$response = array();
-		$response["config"] = array("licenseServerBaseURL" => $wgKalturaUdrmLicenseServerUrl);
-		
-		$responseFlavorData = array();
-		
 		if ($flavorIds) {
 			$responseFlavorData = array();
 			$flavorList = explode(',', $flavorIds);
 			foreach ($flavorList as $flavorId) {
-				$responseFlavorData[$flavorId] = $flavorData[$flavorId];
+				$responseFlavorData[$flavorId] = $fullFlavorData[$flavorId];
 			}
 		} else {
-			$responseFlavorData = $flavorData;
+			$responseFlavorData = $fullFlavorData;
 		}
+		return $responseFlavorData;
+	}
+	
+	function getMissingParams() {
+		// Check mandatory parameters (wid, uiconf_id, entry_id, ks)
+		$mandatory = array(wid, uiconf_id, entry_id, ks);
+		$missing = array();
+		foreach ($mandatory as $param) {
+			if (!isset($_REQUEST[$param])) {
+				$missing[] = $param;
+			}
+		}
+		return $missing;
+	}
+
+	function run() {
+		global $wgKalturaUdrmLicenseServerUrl;
+
+		// Always send 200, errors are signalled in json.		
+		$this->sendHeaders();
 		
-		$response["flavorData"] = $responseFlavorData;
+		$response = array();
+		
+		$missingParams = $this->getMissingParams();
+		
+		if (!$missingParams) {
+			try {
+				$flavorData = $this->getRawFlavorData();				
+				$response = array(
+					"config" 		=> array("licenseServerBaseURL" => $wgKalturaUdrmLicenseServerUrl),
+					"flavorData"	=> $this->filterByRequestedFlavors($flavorData)
+				);
+		
+			} catch (Exception $e) {
+				// EntryResult throws an exception when something's wrong
+				$response = array(
+					"error" => array(
+						"message" => $e->getMessage()
+					)
+				);
+			}
+		} else {
+			$response = array(
+				"error" => array(
+					"message" => "Missing mandatory parameter(s): " . implode(", ", $missingParams)
+				)
+			);
+		}
 
 		echo json_encode($response);
 	}
-	
 
 	function sendHeaders() {
 		// Set content type
@@ -69,17 +107,11 @@ class mweApiGetLicenseData {
 		header("Pragma: no-cache"); // 	for HTTP/1.0
 	}
 	
-	function getData() {
+	function getRawFlavorData() {
 		global $container;
 		$drmPluginData = null;
-		try {
-			// When EntryResult fails to parse some parameters (most notably ks), it fails when loaded.
-			$resultObject = $container['entry_result']->getResult();
-			$drmPluginData = (array)$resultObject["contextData"]->pluginData["KalturaDrmEntryContextPluginData"];
-			return $drmPluginData["flavorData"];
-		} catch (Exception $e) {
-			error_log("mweApiGetLicenseData: Failed to parse request: \n" . $e);
-			return null;
-		}
+		$resultObject = $container['entry_result']->getResult();
+		$drmPluginData = (array)$resultObject["contextData"]->pluginData["KalturaDrmEntryContextPluginData"];
+		return $drmPluginData["flavorData"];
 	}
 }

--- a/modules/KalturaSupport/apiServices/mweApiGetLicenseData.php
+++ b/modules/KalturaSupport/apiServices/mweApiGetLicenseData.php
@@ -13,7 +13,7 @@
 			"flavor1": {"custom_data": "...", "signature": "..."},
 			"flavor2": {"custom_data": "...", "signature": "..."}
 		},
-		"
+		"licenseServerBaseURL": "https://drm.example.com/license"
 	}
 */
 

--- a/modules/KalturaSupport/apiServices/mweApiGetLicenseData.php
+++ b/modules/KalturaSupport/apiServices/mweApiGetLicenseData.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+	Returns json with license acquisition data. 
+	Required parameters:
+		wid, uiconf_id, entry_id, ks
+	Optional parameter:
+		flavor_ids  (comma-separated list)
+		
+	Return value:
+	{
+		"flavorData": {
+			"flavor1": {"custom_data": "...", "signature": "..."},
+			"flavor2": {"custom_data": "...", "signature": "..."}
+		},
+		"
+	}
+*/
+
+
+$wgMwEmbedApiServices['getLicenseData'] = 'mweApiGetLicenseData';
+
+require_once( dirname( __FILE__ ) . '/../KalturaCommon.php' );
+
+class mweApiGetLicenseData {
+
+	function run() {
+		global $wgKalturaUdrmLicenseServerUrl;
+
+		$flavorData = $this->getData();
+
+		$this->sendHeaders();
+		
+		if (!$flavorData) {
+			echo "{}";
+			return;
+		}
+		
+		// Filter by flavor_ids, if specified.
+		$flavorIds = $_REQUEST["flavor_ids"];
+		
+		$response = array();
+		$response["config"] = array("licenseServerBaseURL" => $wgKalturaUdrmLicenseServerUrl);
+		
+		$responseFlavorData = array();
+		
+		if ($flavorIds) {
+			$responseFlavorData = array();
+			$flavorList = explode(',', $flavorIds);
+			foreach ($flavorList as $flavorId) {
+				$responseFlavorData[$flavorId] = $flavorData[$flavorId];
+			}
+		} else {
+			$responseFlavorData = $flavorData;
+		}
+		
+		$response["flavorData"] = $responseFlavorData;
+
+		echo json_encode($response);
+	}
+	
+
+	function sendHeaders() {
+		// Set content type
+		header("Content-type: application/json");
+		
+		// Set no cache
+		header("Cache-Control: no-cache, must-revalidate");
+		header("Pragma: no-cache"); // 	for HTTP/1.0
+	}
+	
+	function getData() {
+		global $container;
+		$drmPluginData = null;
+		try {
+			// When EntryResult fails to parse some parameters (most notably ks), it fails when loaded.
+			$resultObject = $container['entry_result']->getResult();
+			$drmPluginData = (array)$resultObject["contextData"]->pluginData["KalturaDrmEntryContextPluginData"];
+			return $drmPluginData["flavorData"];
+		} catch (Exception $e) {
+			error_log("mweApiGetLicenseData: Failed to parse request: \n" . $e);
+			return null;
+		}
+	}
+}


### PR DESCRIPTION
Returns a json object with license data (custom_data and signature) for each flavor of a given entry id. Also returns license server base url.