### PR TITLE
start monitor on native onplay event

### DIFF
--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
@@ -866,8 +866,6 @@
 							vid.play();
 						}
 						_this.mobilePlayed = true;
-						// re-start the monitor:
-						_this.monitor();
 					}
 				} else {
 					_this.log(" parent play returned false, don't issue play on native element");
@@ -1173,6 +1171,8 @@
 			}
 			// Set firstEmbedPlay state to false to avoid initial play invocation :
 			this.ignoreNextNativeEvent = false;
+			// re-start the monitor:
+			this.monitor();
 		},
 
 		/**


### PR DESCRIPTION
start monitor on native onplay event instead of when clicking our play button. Fix for iPhone not restoring monitor after pause in native video player.