### PR TITLE
FEC-4723 #comment Better and safer way of passing supported formats.

### DIFF
--- a/kWidget/kWidget.js
+++ b/kWidget/kWidget.js
@@ -200,6 +200,36 @@
 					}
 				}
 			}
+
+            if (mw.getConfig( 'EmbedPlayer.ForceNativeComponent')) {
+                // set up window.kNativeSdk
+                window.kNativeSdk = window.kNativeSdk || {};
+
+                var typeMap = function(names) {
+                    if (typeof names !== 'string') {
+                        return [];
+                    }
+                    names = names.split(",");
+                    var mimeTypes = [];
+                    var map = {
+                        "dash": "application/dash+xml",
+                        "mp4":  "video/mp4",
+                        "wvm":  "video/wvm",
+                        "hls":  "application/vnd.apple.mpegurl",
+                    };
+                    for (var i = 0; i < names.length; i++) {
+                        mimeTypes.push(map[names[i]]);
+                    }
+                    return mimeTypes;
+                };
+                
+                // The Native SDK provides two lists of supported formats, after the hash sign.
+                // Example: #nativeSdkDrmFormats=dash,wvm&nativeSdkAllFormats=dash,mp4,hls,wvm
+                var drmFormats = kWidget.getHashParam("nativeSdkDrmFormats") || "wvm";
+                var allFormats = kWidget.getHashParam("nativeSdkAllFormats") || "wvm,mp4,hls";
+                window.kNativeSdk.drmFormats = typeMap(drmFormats);
+                window.kNativeSdk.allFormats = typeMap(allFormats);
+			}
 		},
 
 		/**

--- a/modules/EmbedPlayer/resources/mw.EmbedTypes.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedTypes.js
@@ -15,22 +15,7 @@
 
 
 //Native Mobile player
-var nativeComponentPlayerVideo = (function() {
-    // Assuming window.kNativeSDK.supportedFormats holds an object with this structure:
-    // {"drmTypes":["video/wvm","application/dash+xml"],"clearTypes":["application/vnd.apple.mpegurl","video/mp4","application/dash+xml"],"allTypes":["application/vnd.apple.mpegurl","video/wvm","video/mp4","application/dash+xml"]}
-    var nativeFormats = window.kNativeSDK ? window.kNativeSDK.supportedFormats : null;
-    if (nativeFormats) {
-        // Get all supported mimetypes.
-        nativeFormats = nativeFormats.allTypes;
-    } else {
-        // legacy
-        nativeFormats = ['video/h264', 'video/mp4', 'application/vnd.apple.mpegurl', 'video/wvm'];
-    }
-    return new mw.MediaPlayer( 'nativeComponentPlayer', nativeFormats, 'NativeComponent' );
-})();
-
-
-
+var nativeComponentPlayerVideo = new mw.MediaPlayer( 'nativeComponentPlayer', window.kNativeSdk.allFormats, 'NativeComponent' );
 
 // Flash based players:
 var kplayer = new mw.MediaPlayer('kplayer', ['video/live', 'video/kontiki', 'video/x-flv', 'video/h264', 'video/mp4', 'audio/mpeg', 'application/x-shockwave-flash', 'application/vnd.apple.mpegurl'], 'Kplayer');

--- a/modules/EmbedPlayer/resources/mw.MediaPlayers.js
+++ b/modules/EmbedPlayer/resources/mw.MediaPlayers.js
@@ -57,8 +57,7 @@ mw.MediaPlayers.prototype = {
 			this.defaultPlayers['application/vnd.apple.mpegurl'].push('Kplayer');
 		}
 		// If nativeComponent can play dash, use it.
-        var nativeFormats = window.kNativeSDK ? window.kNativeSDK.supportedFormats : null;
-        if (nativeFormats && $.inArray('application/dash+xml', nativeFormats.allTypes)>=0) {
+        if ($.inArray('application/dash+xml', window.kNativeSdk.allFormats) >= 0) {
             this.defaultPlayers['application/dash+xml'] = ['NativeComponent'];
         }
 	},

--- a/modules/MultiDRM/MultiDRM.loader.js
+++ b/modules/MultiDRM/MultiDRM.loader.js
@@ -7,13 +7,7 @@
 		return (window['MediaSource'] || window['WebKitMediaSource']) && !mw.isFirefox() && !mw.isDesktopSafari() && !mw.isMobileChrome();
 	}
 
-    var nativeSdkDRMTypes = (function() {
-        if (window.kNativeSDK) {
-            return window.kNativeSDK.supportedFormats.drmTypes;
-        } else {
-            return ['video/wvm'];
-        }
-    })();
+    var nativeSdkDRMTypes = window.kNativeSdk.drmFormats;
 
 	//Load 3rd party plugins if DRM sources are available
 	mw.addKalturaConfCheck( function( embedPlayer, callback ){


### PR DESCRIPTION
Instead of directly injecting window.kNativeSDK.supportedFormats into the webview from native code, pass the same information on the URL's fragment section.
The fragment is parsed in kWidget.js, which expects

    #nativeSdkDrmFormats=dash,wvm&nativeSdkAllFormats=dash,mp4,hls,wvm

It then sets window.kNativeSdk.drmFormats and .allFormats with the matching mime types.