### PR TITLE
remove "path" Flashvar from demo pages

### DIFF
--- a/modules/DoubleClick/tests/DoubleClickAdEvents.qunit.html
+++ b/modules/DoubleClick/tests/DoubleClickAdEvents.qunit.html
@@ -183,8 +183,6 @@
 		'flashvars': {
 			'doubleClick':{
 				'plugin':true,
-				//'leadWithFlash': false,
-				'path' : 'http://cdnbakmi.kaltura.com/content/uiconf/ps/veria/kdp3.9.1/plugins/doubleclickPlugin.swf',
 				//'adTagUrl': 'http://pubads.g.doubleclick.net/gampad/ads?sz=400x300&iu=%2F6062%2Fiab_vast_samples&ciu_szs=300x250%2C728x90&impl=s&gdfp_req=1&env=vp&output=xml_vast2&unviewed_position_start=1&url=[referrer_url]&correlator=[timestamp]&cust_params=iab_vast_samples%3Dlinear',
 				//'adTagUrl': 'http://pubads.g.doubleclick.net/gampad/ads?sz=400x300&iu=%2F6062%2Fiab_vast_samples&ciu_szs=300x250%2C728x90&impl=s&gdfp_req=1&env=vp&output=xml_vast2&unviewed_position_start=1&url=[referrer_url]&correlator=[timestamp]&cust_params=iab_vast_samples%3Dimageoverlay',
 				'adTagUrl': 'http://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=%2F3510761%2FadRulesSampleTags&ciu_szs=160x600%2C300x250%2C728x90&cust_params=adrule%3Dpremidpostwithpod&impl=s&gdfp_req=1&env=vp&ad_rule=1&vid=12345&cmsid=3601&output=xml_vast2&unviewed_position_start=1&url=[referrer_url]&correlator=[timestamp]',

--- a/modules/DoubleClick/tests/DoubleClickCompanionsAutomaticFlashHLSContent.html
+++ b/modules/DoubleClick/tests/DoubleClickCompanionsAutomaticFlashHLSContent.html
@@ -56,7 +56,7 @@
 				//'adTagUrl': 'http://pubads.g.doubleclick.net/gampad/ads?sz=400x300&iu=%2F6062%2Fiab_vast_samples&ciu_szs=300x250%2C728x90&impl=s&gdfp_req=1&env=vp&output=xml_vast2&unviewed_position_start=1&url=[referrer_url]&correlator=[timestamp]&cust_params=iab_vast_samples%3Dlinear',
 				//'adTagUrl': 'http://pubads.g.doubleclick.net/gampad/ads?sz=400x300&iu=%2F6062%2Fiab_vast_samples&ciu_szs=300x250%2C728x90&impl=s&gdfp_req=1&env=vp&output=xml_vast2&unviewed_position_start=1&url=[referrer_url]&correlator=[timestamp]&cust_params=iab_vast_samples%3Dimageoverlay',
 				'adTagUrl': 'http://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/ad_rule_samples&ciu_szs=300x250&ad_rule=1&impl=s&gdfp_req=1&env=vp&output=xml_vmap1&unviewed_position_start=1&cust_params=sample_ar%3Dpreonly&cmsid=496&vid=short_onecue&correlator=[timestamp]',
-				'disableCompanionAds' : false,
+				'disableCompanionAds' : false
 			},
 			'LeadWithHLSOnFlash': true,
 			//'debugMode':'true',

--- a/modules/DoubleClick/tests/DoubleClickCompanionsManual.html
+++ b/modules/DoubleClick/tests/DoubleClickCompanionsManual.html
@@ -23,7 +23,6 @@
 		'flashvars': {
 			'doubleClick':{
 				'plugin':true,
-				'leadWithFlash':true,
 				'adTagUrl': 'http://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/ad_rule_samples&ciu_szs=300x250&ad_rule=1&impl=s&gdfp_req=1&env=vp&output=xml_vmap1&unviewed_position_start=1&cust_params=sample_ar%3Dpreonly&cmsid=496&vid=short_onecue&correlator=[timestamp]',
 				'disableCompanionAds' : false,
 				'htmlCompanions': 'testCompanionSquare:300:250;testCompanionLong:728:90',

--- a/modules/DoubleClick/tests/DoubleClickManagedForceFlash.qunit.html
+++ b/modules/DoubleClick/tests/DoubleClickManagedForceFlash.qunit.html
@@ -135,7 +135,6 @@ Linear Ad</a>
                 'ForceFlashOnDesktopSafari':true,
                 'doubleClick': {
                     'plugin': true ,
-                    'path': 'http://cdnbakmi.kaltura.com/content/uiconf/ps/veria/kdp3.9.1/plugins/doubleclickPlugin.swf' ,
                     'adTagUrl': atTagURL ,
                     'disableCompanionAds': false ,
 	                'htmlCompanions': 'testCompanionSquare:300:250;testCompanionLong:728:90',

--- a/modules/DoubleClick/tests/DoubleClickManagedPlayerAdApi.qunit.html
+++ b/modules/DoubleClick/tests/DoubleClickManagedPlayerAdApi.qunit.html
@@ -135,7 +135,6 @@ Linear Ad</a>
                 'ForceFlashOnDesktopSafari':true,
                 'doubleClick': {
                     'plugin': true ,
-                    'path': 'http://cdnbakmi.kaltura.com/content/uiconf/ps/veria/kdp3.9.1/plugins/doubleclickPlugin.swf' ,
                     'adTagUrl': atTagURL ,
                     'disableCompanionAds': false ,
 	                'htmlCompanions': 'testCompanionSquare:300:250;testCompanionLong:728:90',

--- a/modules/DoubleClick/tests/DoubleClickNoticeMessage.html
+++ b/modules/DoubleClick/tests/DoubleClickNoticeMessage.html
@@ -31,7 +31,6 @@ The following Flashvars control the notice message:<br>
 		'flashvars': {
 			'doubleClick':{
 				'plugin':true,
-				'path' : 'http://cdnbakmi.kaltura.com/content/uiconf/ps/veria/kdp3.9.1/plugins/doubleclickPlugin.swf',
 				'adTagUrl': 'http://pubads.g.doubleclick.net/gampad/ads?sz=400x300&iu=%2F6062%2Fiab_vast_samples&ciu_szs=300x250%2C728x90&impl=s&gdfp_req=1&env=vp&output=xml_vast2&unviewed_position_start=1&url=[referrer_url]&correlator=[timestamp]&cust_params=iab_vast_samples%3Dlinear',
 				'disableCompanionAds' : false,
 				'debugMode':false,

--- a/modules/DoubleClick/tests/DoubleClickPlaylist.html
+++ b/modules/DoubleClick/tests/DoubleClickPlaylist.html
@@ -99,7 +99,6 @@
 			},
 			'doubleClick': {
 				'plugin': true,
-				'path': 'http://cdnbakmi.kaltura.com/content/uiconf/ps/veria/kdp3.9.1/plugins/doubleclickPlugin.swf',
 				'adTagUrl':"http://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/ad_rule_samples&ciu_szs=300x250&ad_rule=1&impl=s&gdfp_req=1&env=vp&output=xml_vmap1&unviewed_position_start=1&cust_params=sample_ar%3Dpreonly&cmsid=496&vid=short_onecue&correlator=[timestamp]",
 				'disableCompanionAds': false,
 				'postSequence': '0',

--- a/modules/DoubleClick/tests/DoubleClickSkipLocale.html
+++ b/modules/DoubleClick/tests/DoubleClickSkipLocale.html
@@ -24,7 +24,6 @@
 			'localizationCode':'de',
 			'doubleClick':{
 				'plugin':true,
-				'path' : 'http://cdnbakmi.kaltura.com/content/uiconf/ps/veria/kdp3.9.1/plugins/doubleclickPlugin.swf',
 				'adTagUrl': 'http://pubads.g.doubleclick.net/gampad/ads?sz=640x360&iu=/6062/iab_vast_samples/skippable&ciu_szs=300x250,728x90&impl=s&gdfp_req=1&env=vp&output=xml_vast2&unviewed_position_start=1&url=[referrer_url]&correlator=[timestamp]',
 				'disableCompanionAds' : false,
 				'debugMode':false

--- a/modules/DoubleClick/tests/DoubleClickStreamerType.html
+++ b/modules/DoubleClick/tests/DoubleClickStreamerType.html
@@ -24,7 +24,6 @@
 			'streamerType': 'hdnetwork',
 			'doubleClick':{
 				'plugin':true,
-				'path' : 'http://cdnbakmi.kaltura.com/content/uiconf/ps/veria/kdp3.9.1/plugins/doubleclickPlugin.swf',
 				//'adTagUrl': 'http://pubads.g.doubleclick.net/gampad/ads?sz=400x300&iu=%2F6062%2Fiab_vast_samples&ciu_szs=300x250%2C728x90&impl=s&gdfp_req=1&env=vp&output=xml_vast2&unviewed_position_start=1&url=[referrer_url]&correlator=[timestamp]&cust_params=iab_vast_samples%3Dlinear',
 				//'adTagUrl': 'http://pubads.g.doubleclick.net/gampad/ads?sz=400x300&iu=%2F6062%2Fiab_vast_samples&ciu_szs=300x250%2C728x90&impl=s&gdfp_req=1&env=vp&output=xml_vast2&unviewed_position_start=1&url=[referrer_url]&correlator=[timestamp]&cust_params=iab_vast_samples%3Dimageoverlay',
 				'adTagUrl': 'http://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/ad_rule_samples&ciu_szs=300x250&ad_rule=1&impl=s&gdfp_req=1&env=vp&output=xml_vmap1&unviewed_position_start=1&cust_params=sample_ar%3Dpremidpost&cmsid=496&vid=short_onecue&correlator=[timestamp]',

--- a/modules/DoubleClick/tests/DoubleClickUseFlash.html
+++ b/modules/DoubleClick/tests/DoubleClickUseFlash.html
@@ -2,14 +2,14 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-    <title> DoubleClick using Javascript </title>
+    <title> DoubleClick using Flash </title>
 
     <script type="text/javascript" src="../../../tests/qunit/qunit-bootstrap.js"></script>
     <script type="text/javascript" src="../../../mwEmbedLoader.php"></script>
     <script type="text/javascript" src="../../../docs/js/doc-bootstrap.js"></script>
 </head>
 <body>
-<h3>DoubleClick using Javascript</h3>
+<h3>DoubleClick using Flash</h3>
 <div id="videoTarget" style="width:600px;height:430px"></div>
 <script>
     kWidget.featureConfig({
@@ -21,8 +21,7 @@
         'flashvars': {
             'doubleClick':{
                 'plugin':true,
-                'leadWithFlash': false,
-                'path' : 'http://cdnbakmi.kaltura.com/content/uiconf/ps/veria/kdp3.9.1/plugins/doubleclickPlugin.swf',
+                'leadWithFlash': true,
                 'adTagUrl': 'http://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/ad_rule_samples&ciu_szs=300x250&ad_rule=1&impl=s&gdfp_req=1&env=vp&output=xml_vmap1&unviewed_position_start=1&cust_params=sample_ar%3Dpremidpost&cmsid=496&vid=short_onecue&correlator=[timestamp]',
                 'disableCompanionAds' : false,
                 'debugMode':false

--- a/modules/DoubleClick/tests/DoubleClickVPAID.html
+++ b/modules/DoubleClick/tests/DoubleClickVPAID.html
@@ -25,7 +25,6 @@
             'ForceFlashOnDesktopSafari' : true,
 			'doubleClick':{
 				'plugin':true,
-				'path' : 'http://cdnbakmi.kaltura.com/content/uiconf/ps/veria/kdp3.9.1/plugins/doubleclickPlugin.swf',
 				'adTagUrl': localPath+'liverailOnlyFlash.xml?random={utility.random}&timestamp={utility.timestamp}&referrer_url={utility.referrer_url}&referrer_host={utility.referrer_host}',
 				'disableCompanionAds' : false,
 				'debugMode':false


### PR DESCRIPTION
Also remove leadWithFlash: false as we now lead with Javascript. Created a test page with leadWithFlash: true to show forcing usage of the IMA Flash SDK 