### PR TITLE
Make sure that flash is supported by the browser before adding a flash vpaid ad to the valid ad container in the adConf object.

### DIFF
--- a/modules/AdSupport/resources/mw.VastAdParser.js
+++ b/modules/AdSupport/resources/mw.VastAdParser.js
@@ -168,7 +168,7 @@ mw.VastAdParser = {
 					currentAd.companions.push( staticResource );
 				}
 			});
-			
+
 			// look for icons
 			currentAd.icons = [];
 			$ad.find('Icons Icon').each( function( na, icon ){
@@ -185,8 +185,12 @@ mw.VastAdParser = {
 
 			});
 			addVideoClicksIfExist();
-			if (( currentAd.videoFiles && currentAd.videoFiles.length > 0 ) || currentAd.vpaid) {
-				adConf.ads.push( currentAd );
+			if (
+			    ( currentAd.videoFiles && currentAd.videoFiles.length > 0 ) ||
+			    ( currentAd.vpaid && currentAd.vpaid.js ) ||
+			    ( currentAd.vpaid && currentAd.vpaid.flash && mw.supportsFlash() ) ||
+			    ( currentAd.nonLinear && currentAd.nonLinear.length > 0) ) {
+			    adConf.ads.push( currentAd );
 			}
 		});
 		adConf.videoClickTracking = _this.videoClickTrackingUrl;


### PR DESCRIPTION
Make sure that flash is supported by the browser before adding a flash vpaid ad to the valid ad container in the adConf object.

This resolved the issue in which loading a flash VPAID ad triggers adStart, adEnd, preSequenceStart/Completed, etc. events even when no ad was ever loaded and played.