### PR TITLE
bug fix for WEBC-3728

### DIFF
--- a/modules/QnA/resources/qnaService.js
+++ b/modules/QnA/resources/qnaService.js
@@ -242,8 +242,8 @@ DAL for Q&A Module
                 "filter:systemNameEqual": this.QandA_MetadataProfileSystemName
             };
 
-            this.getKClient().doRequest([listMetadataProfileRequest], function (result) {
-                _this.metadataProfile = result[0].objects[0];
+            this.getKClient().doRequest(listMetadataProfileRequest, function (result) {
+                _this.metadataProfile = result.objects[0];
                 _this.userId=_this.qnaPlugin.getUserID();
                 deferred.resolve();
             });


### PR DESCRIPTION
when we do a multi request with 1 request in it, and the player calls
startWidgetSession inside we get a single object and not an an array,
so this needs to be changed