### PR TITLE
Fix mw.versionIsAtLeast() to handle non-numeric values.

### DIFF
--- a/modules/MwEmbedSupport/mw.MwEmbedSupport.js
+++ b/modules/MwEmbedSupport/mw.MwEmbedSupport.js
@@ -222,6 +222,9 @@ Date.now = Date.now || function(){ return +new Date; };
 		if( typeof clientVersion == 'undefined' ){
 			clientVersion = window.MWEMBED_VERSION;
 		}
+		// strip all non-numeric values from both strings: 
+		minVersion = minVersion.replace(/[^\d.-]/g, '');
+		clientVersion = clientVersion.replace(/[^\d.-]/g, '');
 		var minVersionParts = minVersion.split('.');
 		var clientVersionParts = clientVersion.split('.');
 		for( var i =0; i < minVersionParts.length; i++ ) {


### PR DESCRIPTION
Taken from the other copy of this function at 3a1cc6c305f3f9bc4568f5c6e720c3bf946726a3.
