### PR TITLE
FEC-5474

### DIFF
--- a/modules/DoubleClick/resources/mw.DoubleClick.js
+++ b/modules/DoubleClick/resources/mw.DoubleClick.js
@@ -1147,6 +1147,7 @@
 
 					// for preroll ad that doesn't play using our video tag - we can load our video tag to improve performance once the ad finish
 					if ( _this.currentAdSlotType === "preroll" && !_this.adsManager.isCustomPlaybackUsed() ){
+						_this.embedPlayer._propagateEvents = true;
 						_this.embedPlayer.load();
 					}
 				}else{

--- a/modules/KalturaSupport/components/sourceSelector.js
+++ b/modules/KalturaSupport/components/sourceSelector.js
@@ -255,7 +255,7 @@
                 return true;
             }
 
-            if ( this.getPlayer().streamerType != "http" && !this.getPlayer().isPlaying() ){
+            if ( this.getPlayer().streamerType != "http" && !this.getPlayer().isPlaying() && !this.getPlayer().isInSequence() ){
                 if((this.getPlayer().streamerType !== "hls" && !mw.EmbedTypes.getMediaPlayers().isSupportedPlayer('kplayer')) &&//If flash disabled, player fallback to http progressive, but the streamerType might still be hdnetwork
 					(this.getPlayer().streamerType !== "smoothStream" && !mw.EmbedTypes.getMediaPlayers().isSupportedPlayer('splayer'))){
                     return true;


### PR DESCRIPTION
pass events when loading entry during preroll. Do not populate ABR sources during ads.