### PR TITLE
FEC-5482 #comment Set the default to 0 if non is selected

### DIFF
--- a/modules/KalturaSupport/components/audioSelector.js
+++ b/modules/KalturaSupport/components/audioSelector.js
@@ -34,6 +34,7 @@
 					defaultTrack: this.getConfig('defaultStream')
 				};
 			}
+			this.setConfig('defaultStream', 0);
 		},
 		destroy: function () {
 			this._super();


### PR DESCRIPTION
-1 option is to inform playback engines not to try and set default on
load (happens in silverlight player)