### PR TITLE
Fix error in DoubleClick skip button

### DIFF
--- a/modules/DoubleClick/resources/mw.DoubleClick.js
+++ b/modules/DoubleClick/resources/mw.DoubleClick.js
@@ -716,6 +716,11 @@
 			}
 		},
 		showSkipBtn: function(){
+			var offset = this.embedPlayer.getKalturaConfig( 'skipBtn', 'skipOffset' ) || 15;
+			if ( this.duration < offset ){
+				return
+			}
+
 			if( this.embedPlayer.getKalturaConfig( 'skipBtn', 'skipOffset' ) ){
 				$(".ad-skip-label").show();
 				this.skipTimeoutId = setTimeout(function(){


### PR DESCRIPTION
When an ad has a shorter duration than the skipOffset, the hideSkip button method will not be called, because all ad functionality gets broken down after the ad finishes. Leaving the skip button permanently in place. This update will not show the button at all, since it is not necessary in those circumstances.