### PR TITLE
Changed the CURL TIMEOUT to 1 second

### DIFF
--- a/simplePhpXMLProxy.php
+++ b/simplePhpXMLProxy.php
@@ -216,8 +216,8 @@ if ( !$url ) {
 	// Always follow redirects: 
 	curl_setopt( $ch, CURLOPT_AUTOREFERER, true );
 		
-	// Add a total curl execute timeout of 10 seconds: 
-	curl_setopt( $ch, CURLOPT_TIMEOUT, 10 );
+	// Add a total curl execute timeout of 1 second: 
+	curl_setopt( $ch, CURLOPT_TIMEOUT, 1 );
 	
 	if ( strtolower($_SERVER['REQUEST_METHOD']) == 'post' ) {
 		curl_setopt( $ch, CURLOPT_POST, true );


### PR DESCRIPTION
Changed the 10 seconds TIMEOUT to 1 second. This setting can consume all the PHP slots on a busy enviroment when an adserver is slow, and bring the platform down. This happened for real on a big deployment.

It is a super simple change but critical (IMHO)

Thanks! 
