### PR TITLE
Reducing isLive cache expiry to 5 seconds

### DIFF
--- a/modules/KalturaSupport/components/live/liveCore.js
+++ b/modules/KalturaSupport/components/live/liveCore.js
@@ -460,6 +460,10 @@
             if ( mw.isIOS8_9() ) {
                 requestObj.rnd = Math.random();
             }
+            		
+            		var oldExpiry = _this.getKalturaClient().baseParam.expiry;
+			_this.getKalturaClient().baseParam.expiry = 5; //Setting is live expiry to 5 seconds
+			
 			_this.getKalturaClient().doRequest( requestObj, function( data ) {
 				var onAirStatus = false;
 				if ( data === true ) {
@@ -473,6 +477,8 @@
 				mw.log("Error occur while trying to check onAir status");
 				embedPlayer.triggerHelper( 'liveStreamStatusUpdate', { 'onAirStatus' : false } );
 			} );
+			
+			_this.getKalturaClient().baseParam.expiry = oldExpiry; //Setting expiry back to old value
 		},
 
 		getKalturaClient: function() {


### PR DESCRIPTION
Fixes issue where isLive is cached on the backend and streams loads only after several minutes
@itaykinnrot , @amirch1 - Not sure who should I contact regarding that, but I think this is a valuable fix.
