### PR TITLE
workaround for non sibling preroll

### DIFF
--- a/modules/FreeWheel/resources/mw.FreeWheelController.js
+++ b/modules/FreeWheel/resources/mw.FreeWheelController.js
@@ -491,6 +491,9 @@ mw.FreeWheelController.prototype = {
 
 		if( slotType== 'preroll' ){
 			_this.getContext().setVideoState( tv.freewheel.SDK.VIDEO_STATE_PLAYING );
+			if( mw.isFirefox() && mw.getConfig('isHLS_JS') === true ) {
+				_this.embedPlayer.triggerHelper( 'reset' );
+			}
 		}
 		if( slotType == 'postroll' ){
 			_this.getContext().setVideoState( tv.freewheel.SDK.VIDEO_STATE_COMPLETED) ;

--- a/modules/FreeWheel/tests/FreeWheelPlayer.html
+++ b/modules/FreeWheel/tests/FreeWheelPlayer.html
@@ -23,23 +23,31 @@ function jsKalturaPlayerTest( videoId ){
 <script>
 	kWidget.featureConfig({
 		'targetId': 'myVideoTarget',
-		'wid': '_243342',
+		'wid': '_1878761',
 		'uiconf_id' : '14945112',
-		'entry_id' : '0_uka1msg4',
+		'entry_id' : '1_usagz19w',// Harold video replaced since it has bad decoding for hls.js
 		'flashvars': {
+			/*
+			"hlsjs": {
+			    "plugin": true
+			},
+			"LeadWithHLSOnJs": true,
+			*/
 			'freeWheel': {
-				'adManagerUrl': "http://adm.fwmrm.net/p/release/latest-AS3/adm/dbg/AdManager.swf",
-				'adManagerJsUrl': "http://adm.fwmrm.net/p/release/latest-JS/adm/dbg/AdManager.js",
-				'serverUrl': "http://demo.v.fwmrm.net",
-				'networkId': "176538",
-				'playerProfile': "176538:KDP_Flash",
-				'playerProfileHTML5': "176538:KDP_HTML5",
-				'siteSectionId': "defaultsection",
-				'preSequence': "1",
-				'postSequence':"1",
-				'useKalturaTemporalSlots':"true",
-				'videoAssetId':"videopreroll",
-				'videoAssetFallbackId':"videopreroll"
+					'plugin': true,
+					'asyncInit':"true",
+					'adManagerJsUrl':"http://adm.fwmrm.net/p/release/latest-JS/adm/dbg/AdManager.js",
+					'adManagerUrl':"http://adm.fwmrm.net/p/release/latest-AS3/adm/dbg/AdManager.swf",
+					'networkId':"176538",
+					'playerProfile':"176538:KDP_Flash",
+					'playerProfileHTML5':"176538:KDP_HTML5",
+					'postSequence':"1",
+					'preSequence':"1",
+					'serverUrl':"http://demo.v.fwmrm.net",
+					'siteSectionId':"defaultsection",
+					'useKalturaTemporalSlots':"true",
+					'videoAssetFallbackId':"playerdefined",
+					'videoAssetId':"playerdefined"
 			}
 		}
 	})

--- a/modules/Hlsjs/resources/hlsjs.js
+++ b/modules/Hlsjs/resources/hlsjs.js
@@ -69,6 +69,7 @@
 				this.bind("onSelectSource", this.checkIfHLSNeeded.bind(this));
 				this.bind("playerReady", this.initHls.bind(this));
 				this.bind("onChangeMedia", this.clean.bind(this));
+				this.bind("reset", this.reset.bind(this));
 				if( mw.getConfig("hlsLogs") ) {
 					this.bind("monitorEvent", this.monitorDebugInfo.bind(this));
 				}
@@ -132,6 +133,12 @@
 
 					}
 				}
+			},
+			reset: function () {
+				this.clean();
+				this.LoadHLS = true;
+				this.initHls();
+				this.load();
 			},
 			/**
 			 * Register HLS playback engine events


### PR DESCRIPTION
Freewheel adds a video element to the dom only for midrolls.
In a case of preroll, Freewheel doesn’t create sibling video tag. hls.js on FF
fails to replace source at the end of ad inside the same video tag.
