### PR TITLE
FEC-5595 #comment Fix stuck after mid roll ads in Android

### DIFF
--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
@@ -409,9 +409,7 @@
 			// some initial calls to prime the seek:
 			if ( ( vid.currentTime === 0 && callbackCount === 0 ) && vid.readyState === 0 ) { //load video again if not loaded yet (vid.readyState === 0)
 				// when seeking turn off preload none and issue a load call.
-				$(vid)
-					.attr('preload', 'auto')
-					[0].load();
+				$(vid).attr('preload', 'auto');
 			}
 
 			var videoReadyState = mw.isIOS8_9() ? 2 : 1; // on iOS8 wait for video state 1 (dataloaded) instead of 1 (metadataloaded)


### PR DESCRIPTION
The issue is related to a new API Chrome has introduced on v50. The new
HTMLMEDIAELMENT now returns promises.
Currently the solution to this bug is to remove a redundant load method
in the player but need to keep track regarding this change as there are
many open issue around the web, and also a related chromium bug:
https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=2&cad=rja&
uact=8&ved=0ahUKEwjp34Wk1e_MAhWCtBoKHQQRAB8QFggiMAE&url=https%3A%2F%2Fbu
gs.chromium.org%2Fp%2Fchromium%2Fissues%2Fdetail%3Fid%3D593273&usg=AFQjC
NFedgog_DYcjvQ7BfEhHKwxEGqEow&sig2=Q0hHOQe9fx0GbZLkEr5OQg&bvm=bv.1224484
93,d.d24