### PR TITLE
Add localStorage is supported check

### DIFF
--- a/kWidget/kWidget.storage.js
+++ b/kWidget/kWidget.storage.js
@@ -6,7 +6,8 @@
     var storage;
     var isStorageSupported = true;
 
-    function checkLocalStorageSupport(){
+    (function(){
+        debugger;
         try {
             //Check for localStorage object
             var localStorageApiExist = (('localStorage' in win) && (win['localStorage'] != null) && (win['localStorage'] != undefined));
@@ -20,13 +21,13 @@
                 if (fail) {
                     isStorageSupported = false;
                 }
+            } else {
+                isStorageSupported = false;
             }
         } catch (exception) {
             isStorageSupported = false;
         }
-    }
-
-    isStorageSupported = checkLocalStorageSupport();
+    }());
 
     var storageManger = {
         get: function (cacheKey) {

--- a/kWidget/kWidget.storage.js
+++ b/kWidget/kWidget.storage.js
@@ -4,7 +4,7 @@
     var NS = "kalturaCache__";
     var ttlSuffix = "_ttl";
     var storage;
-    var isStorageSupported = false;
+    var isStorageSupported = true;
 
     function checkLocalStorageSupport(){
         try {

--- a/kWidget/kWidget.storage.js
+++ b/kWidget/kWidget.storage.js
@@ -3,7 +3,30 @@
 
     var NS = "kalturaCache__";
     var ttlSuffix = "_ttl";
-    var storage = window.localStorage;
+    var storage;
+    var isStorageSupported = false;
+
+    function checkLocalStorageSupport(){
+        try {
+            //Check for localStorage object
+            var localStorageApiExist = (('localStorage' in win) && (win['localStorage'] != null) && (win['localStorage'] != undefined));
+            if (localStorageApiExist) {
+                //Check for localStorage functionality
+                storage = window.localStorage;
+                var uid = new Date();
+                storage.setItem(uid, uid);
+                var fail = (storage.getItem(uid) != uid);
+                storage.removeItem(uid);
+                if (fail) {
+                    isStorageSupported = false;
+                }
+            }
+        } catch (exception) {
+            isStorageSupported = false;
+        }
+    }
+
+    isStorageSupported = checkLocalStorageSupport();
 
     var storageManger = {
         get: function (cacheKey) {
@@ -78,12 +101,7 @@
             return count;
         },
         isSupported: function() {
-            try {
-                return (('localStorage' in win) && (win['localStorage'] != null) && (win['localStorage'] != undefined));
-            }
-            catch(err) {
-                return false;
-            }
+            return isStorageSupported;
         },
         isQuotaExceeded: function(e) {
             var quotaExceeded = false;

--- a/kWidget/kWidget.storage.js
+++ b/kWidget/kWidget.storage.js
@@ -7,7 +7,6 @@
     var isStorageSupported = true;
 
     (function(){
-        debugger;
         try {
             //Check for localStorage object
             var localStorageApiExist = (('localStorage' in win) && (win['localStorage'] != null) && (win['localStorage'] != undefined));


### PR DESCRIPTION
Avoid throwing exceptions when API is not available, for example when
machine policy prohibits it and just referencing window.localStorage
crashes