### PR TITLE
SUP-8323 stream selector specify base entry type to be only MEDIA_CLIP

### DIFF
--- a/modules/KalturaSupport/components/streamSelector.js
+++ b/modules/KalturaSupport/components/streamSelector.js
@@ -120,6 +120,8 @@
 				'service': 'baseEntry',
 				'action': 'list',
 				'filter:objectType': 'KalturaBaseEntryFilter',
+				// MEDIA_CLIP
+				'filter:typeEqual': 1,
 				'filter:parentEntryIdEqual': this.getPlayer().kentryid
 			});
 


### PR DESCRIPTION
Tested with CaptureSpace entry, works fine, i.e the stream selector is there.