### PR TITLE
SUP-8636 disable the hover controls in KMS and not in the quiz plugin…

### DIFF
--- a/modules/Quiz/resources/quiz.js
+++ b/modules/Quiz/resources/quiz.js
@@ -30,9 +30,7 @@
 
         setup: function () {
             var _this = this;
-            var embedPlayer = _this.getPlayer()
-
-            embedPlayer.disableComponentsHover();
+            var embedPlayer = _this.getPlayer();
             mw.log("Quiz: " + _this.IVQVer);
             this.bind('onChangeStream', function () {
                 mw.log("Quiz: multistream On");


### PR DESCRIPTION
… and using flashvars in deployment quiz player

@OrenMe 
Can't find the right time to disable hovering, so easier solution would be to add it via FlashVar in KMS and as a uiVar for new deployed players in KMS