### PR TITLE
SUP-8636 call getInterface to make sure layout builder exist so we ca…

### DIFF
--- a/modules/Quiz/resources/quiz.js
+++ b/modules/Quiz/resources/quiz.js
@@ -30,8 +30,9 @@
 
         setup: function () {
             var _this = this;
-            var embedPlayer = _this.getPlayer()
-
+            var embedPlayer = _this.getPlayer();
+            // make sure we actually have a layout builder
+            embedPlayer.getInterface();
             embedPlayer.disableComponentsHover();
             mw.log("Quiz: " + _this.IVQVer);
             this.bind('onChangeStream', function () {
@@ -40,7 +41,6 @@
             });
 
             embedPlayer.addJsListener( 'kdpReady', function(){
-
                 _this.KIVQModule = new mw.KIVQModule(embedPlayer, _this);
                 _this.KIVQModule.isKPlaylist = (typeof (embedPlayer.playlist) === "undefined" ) ? false : true;
 


### PR DESCRIPTION
…n disable hover controls

@OrenMe 
New commit. 

it seems that if I call getInterface and make sure that layout builder exist, I can then disable the hover controls. 

Can you please review?

This is Quiz plugin and will be QAed by Application team