### PR TITLE
Set default X-UA-Compatible to IE=edge

### DIFF
--- a/modules/KalturaSupport/kalturaIframeClass.php
+++ b/modules/KalturaSupport/kalturaIframeClass.php
@@ -1266,6 +1266,7 @@ HTML;
 	function getIFramePageOutput( ){
 		$this->inlineScript = false;
 		$flashvars = $this->request->getFlashVars();
+		$playerConfig = $this->getUiConfResult()->getPlayerConfig();
 
 		if (isset($flashvars['inlineScript']) && $flashvars['inlineScript'] == "true"){
 			$this->inlineScript = true;
@@ -1279,9 +1280,17 @@ HTML;
 <!DOCTYPE html>
 <html>
 <head>
-	<?php if(!empty($flashvars['forceCompatMode'])){
-		echo '<meta http-equiv="X-UA-Compatible" content="' . $flashvars['forceCompatMode'] . '"/>';
-	} ?>
+
+	<?php
+        $forceCompatMode = $this->getUiConfResult()->getPlayerConfig(false, 'forceCompatMode');
+        if(!empty($forceCompatMode)){
+            if ($forceCompatMode != "none"){
+                echo '<meta http-equiv="X-UA-Compatible" content="' . $forceCompatMode . '"/>';
+            }
+        } else {
+            echo '<meta http-equiv="X-UA-Compatible" content="IE=edge"/>';
+        }
+	?>
 	<script type="text/javascript"> /*@cc_on@if(@_jscript_version<9){'video audio source track'.replace(/\w+/g,function(n){document.createElement(n)})}@end@*/ </script>
 	<?php if($wgRemoteWebInspector && $wgEnableScriptDebug){
 		echo '<script src="' . $wgRemoteWebInspector . '"></script>';


### PR DESCRIPTION
Can be overridden via flashvar/uiconf by setting attribute
forceCompatMode.
forceCompatMode = none will disable the X-UA-Compatible tag all
together.
Other possible values are as described in MSDN docs.
See
http://stackoverflow.com/questions/6771258/what-does-meta-http-equiv-x-u
a-compatible-content-ie-edge-do for more info.

FEC-5854