### PR TITLE
enhance chromecast receiver performances

### DIFF
--- a/modules/Chromecast/resources/chromecast.js
+++ b/modules/Chromecast/resources/chromecast.js
@@ -92,7 +92,7 @@
 				var ticks = 0;
 				var intervalID = setInterval(function () {
 					ticks++;
-					if (typeof _this.chromeLib !== "undefined" && typeof _this.chromeLib.cast !== "undefined" && _this.chromeLib.cast.isAvailable) {
+					if (_this.chromeLib !== null && typeof _this.chromeLib !== "undefined" && typeof _this.chromeLib.cast !== "undefined" && _this.chromeLib.cast.isAvailable) {
 						_this.initializeCastApi();
 						clearInterval(intervalID);
 					} else {
@@ -690,7 +690,7 @@
 						var mediaInfo = new _this.chromeLib.cast.media.MediaInfo( currentMediaURL );
 						mediaInfo.contentType = mimeType;
 						_this.request = new _this.chromeLib.cast.media.LoadRequest( mediaInfo );
-						_this.request.autoplay = false;
+						_this.request.autoplay = true;
 						_this.request.currentTime = 0;
 
 						var payload = {

--- a/modules/Chromecast/resources/mw.EmbedPlayerChromecastReceiver.js
+++ b/modules/Chromecast/resources/mw.EmbedPlayerChromecastReceiver.js
@@ -48,18 +48,11 @@
 		],
 
 		setup: function( readyCallback ) {
+			$(this).trigger("chromecastReceiverLoaded");
 			$(this).bind('layoutBuildDone', function(){
 				this.getVideoHolder().find('video').remove();
 			});
-			this.setPlayerElement(parent.document.getElementById('receiverVideoElement'));
 			this.addBindings();
-			this.applyMediaElementBindings();
-			mw.log('EmbedPlayerChromecastReceiver:: Setup. Video element: '+this.getPlayerElement().toString());
-			this.getPlayerElement().src = '';
-			$(this).trigger("chromecastReceiverLoaded");
-			this._propagateEvents = true;
-			$(this.getPlayerElement()).css('position', 'absolute');
-			this.stopped = false;
 			readyCallback();
 		},
 		/**
@@ -71,6 +64,14 @@
 				_this.getVideoHolder().css("backgroundColor","transparent");
 				$("body").css("backgroundColor","transparent");
 
+			});
+			this.bindHelper("loadstart", function(){
+				_this.setPlayerElement(parent.document.getElementById('receiverVideoElement'));
+				_this.applyMediaElementBindings();
+				mw.log('EmbedPlayerChromecastReceiver:: Setup. Video element: '+_this.getPlayerElement().toString());
+				_this._propagateEvents = true;
+				$(_this.getPlayerElement()).css('position', 'absolute');
+				_this.stopped = false;
 			});
 			this.bindHelper("replay", function(){
 				_this.triggerReplayEvent = true;
@@ -173,6 +174,7 @@
 				this.seeking = false;
 				if (this._propagateEvents && !this.isLive()) {
 					this.triggerHelper('seeked', [this.getPlayerElementTime()]);
+					this.triggerHelper("onComponentsHoverEnabled");
 					this.syncCurrentTime();
 					this.updatePlayheadStatus();
 				}

--- a/modules/Chromecast/resources/receiver/mpl.js
+++ b/modules/Chromecast/resources/receiver/mpl.js
@@ -22,16 +22,16 @@ var mediaPlayer = null;  // an instance of cast.player.api.Player
 var playerInitialized = false;
 var isInSequence = false;
 var debugMode = false;
+var kdp;
 
 onload = function () {
-	var kdp;
 	if (debugMode){
 		cast.receiver.logger.setLevelValue(cast.receiver.LoggerLevel.DEBUG);
 		cast.player.api.setLoggerLevel(cast.player.api.LoggerLevel.DEBUG);
 	}
 
 	mediaElement = document.getElementById('receiverVideoElement');
-	mediaElement.autoplay = false;
+	mediaElement.autoplay = true;
 	setMediaElementEvents(mediaElement);
 	mediaManager = new cast.receiver.MediaManager(mediaElement);
 
@@ -115,14 +115,13 @@ onload = function () {
 			customData = payload['value'];
 			setDebugMessage('customData', customData);
 		} else if (payload['type'] === 'load') {
-			setMediaManagerEvents();
+			//setMediaManagerEvents();
 		} else if (payload['type'] === 'notification') {
 			kdp.sendNotification(payload['event'], [payload['data']]); // pass notification event to the player
 		} else if (payload['type'] === 'setLogo') {
 			document.getElementById('logo').style.backgroundImage = "url(" + payload['logo'] + ")";
 		} else if (payload['type'] === 'embed' && !playerInitialized) {
-
-			var playerLib = payload['lib'] + "mwEmbedLoader.php?v=" + Date.now();
+			var playerLib = payload['lib'] + "mwEmbedLoader.php";
 			var s = document.createElement("script");
 			s.type = "text/javascript";
 			s.src = playerLib;
@@ -696,6 +695,8 @@ function setCastReceiverManagerEvents() {
 
 function setMediaElementEvents(mediaElement) {
 	mediaElement.addEventListener('loadstart', function (e) {
+		kdp.sendNotification("loadstart");
+		document.getElementById("kaltura_player").style.visibility = "visible";
 		console.log('######### MEDIA ELEMENT LOAD START');
 		setDebugMessage('mediaElementState', 'Load Start');
 		messageBus.broadcast("mediaElement: Load Start");

--- a/modules/Chromecast/resources/receiver/receiver.html
+++ b/modules/Chromecast/resources/receiver/receiver.html
@@ -2,7 +2,6 @@
 <html>
 <head>
     <style type="text/css">
-        @import url(http://fonts.googleapis.com/css?family=Droid+Serif:400,700);
         body {
             overflow:hidden;
         }
@@ -81,12 +80,11 @@
     </style>
     <script type="text/javascript" src="//www.gstatic.com/cast/sdk/libs/receiver/2.0.0/cast_receiver.js"></script>
     <script type="text/javascript" src="//www.gstatic.com/cast/sdk/libs/mediaplayer/1.0.0/media_player.js"></script>
-    <script   src="https://code.jquery.com/jquery-1.12.4.min.js"   integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ="   crossorigin="anonymous"></script>
     <script>document.write("<script type='text/javascript' src='mpl.js?v=" + Date.now() + "'><\/script>");</script>
 </head>
 
 <body>
-<div id="kaltura_player" style=" width:98%; height: 98%; position: absolute;z-index: 1"></div>
+<div id="kaltura_player" style=" width:98%; height: 98%; position: absolute;z-index: 1; visibility: hidden;"></div>
 <div id="messages">
     <div style="font-size:140%; font-weight:bold; margin-left:0px;" id="title">Sample Receiver with Media Player Library for DASH/SS/HLS Streaming with DRMs</div>
     <div>App State: <span id="applicationState">-</span></div>
@@ -123,7 +121,7 @@
     <span>License Credentials: <span id="licenseCredentials">false</span></span>
 </div>
 <div id="videoHolder">
-    <video id="receiverVideoElement" style="height:98%; width:100%; position: absolute"></video>
+    <video id="receiverVideoElement" style="height:98%; width:100%; position: absolute" autoplay="autoplay"></video>
 </div>
 <div id="logo"></div>
 <div id="kdebug"></div>


### PR DESCRIPTION
1. Remove redundant loading of jQuery and Google font from receiver
2. Hide the player interface until video loads
3. Get player to register to video tag events only after media loads
4. Force auto play
5. Remove cache busting of player library