### PR TITLE
set isPauseLoading to false upon playback

### DIFF
--- a/modules/Chromecast/resources/chromecast.js
+++ b/modules/Chromecast/resources/chromecast.js
@@ -741,6 +741,9 @@
 		},
 
 		stopApp: function() {
+			if (!this.casting){
+				return;
+			}
 			clearInterval(this.monitorInterval);
 			var _this = this;
 			this.getComponent().css("color","white");

--- a/modules/Chromecast/resources/mw.EmbedPlayerChromecastReceiver.js
+++ b/modules/Chromecast/resources/mw.EmbedPlayerChromecastReceiver.js
@@ -188,6 +188,9 @@
 		},
 		// override these functions so embedPlayer won't try to sync time
 		syncCurrentTime: function(){
+			if (this.isPauseLoading && this.currentTime !== this.getPlayerElementTime()){
+				this.isPauseLoading = false;
+			}
 			this.currentTime = this.getPlayerElementTime();
 		},
 

--- a/modules/KalturaSupport/components/largePlayBtn.js
+++ b/modules/KalturaSupport/components/largePlayBtn.js
@@ -57,7 +57,7 @@
 				if( newState == 'load' || newState == 'play' ){
 					_this.hide(true);
 				}
-				if( newState == 'pause' && _this.getPlayer().isPauseLoading && !mw.isChromeCast()){
+				if( newState == 'pause' && _this.getPlayer().isPauseLoading){
 					_this.hide();
 				}
 			});


### PR DESCRIPTION
1. set isPauseLoading to false upon playback to make sure large play button gets hidden during playback. 
2. Don't run stopApp if already stopped casting (seek after stop not working issue)