### PR TITLE
#SUP-8984 fix playbackRateSelector to work with progressive download

### DIFF
--- a/modules/KalturaSupport/resources/uiConfComponents/playbackRateSelector.js
+++ b/modules/KalturaSupport/resources/uiConfComponents/playbackRateSelector.js
@@ -278,7 +278,7 @@
 		 */
 		updatePlaybackRate: function( newSpeed ){
 			// workaround for Firefox and IE - changing playbackRate before media loads causes player to stuck
-			if (this.getPlayer().mediaLoadedFlag && !this.getConfig("serverSpeedPlayback")){
+			if (this.getPlayer().mediaLoadedFlag){
 				if (this.getPlayer().instanceOf === 'Native') {
 					this.getPlayer().getPlayerElement().playbackRate = newSpeed;
 				}


### PR DESCRIPTION
@OrenMe After a fix the was made here https://github.com/kaltura/mwEmbed/pull/2762 to solve the second playback speed increment on iPad, the playback rate selector stopped working with progressive download when 'serverSpeedPlayback' is enabled. 

Checked and verified that now all is working as expected (http, hds, hls). 

