### PR TITLE
Allow the native SDK to prefetch player resources.

### DIFF
--- a/modules/EmbedPlayer/resources/mw.EmbedPlayer.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayer.js
@@ -833,6 +833,13 @@
 			};
 			this.mediaElement.autoSelectSource(baseTimeOptions);
 
+            // Allow the native SDK to prefetch player resources
+            if (!this.mediaElement.selectedSource && mw.getConfig("EmbedPlayer.PreloadNativeComponent")) {
+                this.selectPlayer(mw.EmbedTypes.getNativeComponentPlayerVideo());
+                this.updatePlaybackInterface();
+                return;
+            }
+            
 			// Auto select player based on default order
 			if (this.mediaElement.selectedSource) {
 

--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerNativeComponent.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerNativeComponent.js
@@ -145,16 +145,23 @@
 			if (this.startTime && !this.supportsURLTimeEncoding()) {
 				this.setStartTimeAttribute(this.startTime);
 			}
-			this.resolveSrcURL(this.getSrc()).then(
-				function (resolvedSrc) {
-					mw.log("EmbedPlayerNativeComponent::resolveSrcURL get succeeded");
-					_this.setSrcAttribute( resolvedSrc );
-				},
-				function () {
-					mw.log("EmbedPlayerNativeComponent::resolveSrcURL get failed");
-					_this.setSrcAttribute( _this.getSrc() );
-				}
-			);
+            
+            var selectedSource = this.getSrc();
+            if (!selectedSource && mw.getConfig("EmbedPlayer.PreloadNativeComponent")) {
+                readyCallback();
+
+            } else {
+                this.resolveSrcURL(selectedSource).then(
+                    function (resolvedSrc) {
+                        mw.log("EmbedPlayerNativeComponent::resolveSrcURL get succeeded");
+                        _this.setSrcAttribute( resolvedSrc );
+                    },
+                    function () {
+                        mw.log("EmbedPlayerNativeComponent::resolveSrcURL get failed");
+                        _this.setSrcAttribute( selectedSource );
+                    }
+                );
+            }
 		},
 
 		embedPlayerHTML: function () {


### PR DESCRIPTION
If flashvar "EmbedPlayer.PreloadNativeComponent" is specified:
1. select native component player even without source
2. call the native readyCallback() even without source.

This allows the SDK to open the player with no entry and wait for playerReady.