### PR TITLE
Fix iOS flavor transition jumps back to the video beginning for a split second

### DIFF
--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
@@ -411,7 +411,7 @@
 			// some initial calls to prime the seek:
 			if ( ( vid.currentTime === 0 && callbackCount === 0 ) && vid.readyState === 0 ) { //load video again if not loaded yet (vid.readyState === 0)
 				// when seeking turn off preload none and issue a load call.
-				$(vid).attr('preload', 'auto');
+				$(vid).attr('preload', 'auto')[0].load();
 			}
 
 			var videoReadyState = mw.isIOSAbove7() ? 2 : 1; // on iOS8 wait for video state 1 (dataloaded) instead of 1 (metadataloaded)


### PR DESCRIPTION
@OrenMe 

Revert fix from fec-5595 (98c82fa)