### PR TITLE
Fix getLicenseData on php < 5.4.0.

### DIFF
--- a/modules/KalturaSupport/apiServices/mweApiGetLicenseData.php
+++ b/modules/KalturaSupport/apiServices/mweApiGetLicenseData.php
@@ -120,7 +120,11 @@ class mweApiGetLicenseData {
             );
         }     
         
-		echo json_encode($response, JSON_FORCE_OBJECT | JSON_UNESCAPED_SLASHES);
+        $encode_flags = JSON_FORCE_OBJECT;
+        if (defined("JSON_UNESCAPED_SLASHES")) {
+            $encode_flags |= JSON_UNESCAPED_SLASHES;
+        }
+		echo json_encode($response, $encode_flags);
 	}
 	
 	function sendHeaders() {


### PR DESCRIPTION
JSON_UNESCAPED_SLASHES only exists since php v5.4.0, and some production servers run v5.3.x.

v2.48 also needs this patch (but v2.47 does not).