### PR TITLE
SUP-9408 'updateLayout' infinite loop when CC layout is below

### DIFF
--- a/modules/KalturaSupport/resources/mw.ClosedCaptions.js
+++ b/modules/KalturaSupport/resources/mw.ClosedCaptions.js
@@ -193,7 +193,7 @@
 				}
 			});
 
-			this.bind( 'updateLayout', function(){
+			this.bind( 'onCloseFullScreen onOpenFullScreen', function(){
 				if (_this.getConfig("displayCaptions") == true){
 					_this.updateTextSize();
 				}


### PR DESCRIPTION
@OrenMe In the end did not need to add a flag since the CC change size when open/close full screen (External CC as well).

Revert the first part of this commit - https://github.com/kaltura/mwEmbed/pull/3002
