### PR TITLE
Add CC AD error message on bus

### DIFF
--- a/modules/Chromecast/resources/receiver/mpl.js
+++ b/modules/Chromecast/resources/receiver/mpl.js
@@ -768,6 +768,10 @@ function setCastReceiverManagerEvents() {
 
 		senders = castReceiverManager.getSenders();
 		console.log('after disconnect  senderCount', '' + senders.length);
+		setTimeout(function() {
+			messageBus.broadcast('chromecastReceiverOnSenderDisconneted|' + senders.length);
+		},100);
+
 		if ((senders.length === 0) &&
 			(event.reason == cast.receiver.system.DisconnectReason.REQUESTED_BY_SENDER)) {
 			castReceiverManager.stop();

--- a/modules/Chromecast/resources/receiver/mpl.js
+++ b/modules/Chromecast/resources/receiver/mpl.js
@@ -216,7 +216,8 @@ onload = function () {
 										console.info("Ad ended");
 										loadContent();
 									});
-									kdp.kBind("adErrorEvent", function(){
+									kdp.kBind("adErrorEvent", function(msg){
+										messageBus.broadcast("chromecastReceiverAdError|" + msg);
 										console.info("Ad error");
 										loadContent();
 									});
@@ -751,6 +752,12 @@ function setCastReceiverManagerEvents() {
 
 		senders = castReceiverManager.getSenders();
 		setDebugMessage('senderCount', '' + senders.length);
+
+		if (senders.length > 0) {
+			setTimeout(function() {
+				messageBus.broadcast('chromecastReceiverOnSenderConnected|' + senders.length);
+			},100);
+		}
 	};
 
 	castReceiverManager.onSenderDisconnected = function (event) {
@@ -760,6 +767,7 @@ function setCastReceiverManagerEvents() {
 			JSON.stringify(event));
 
 		senders = castReceiverManager.getSenders();
+		console.log('after disconnect  senderCount', '' + senders.length);
 		if ((senders.length === 0) &&
 			(event.reason == cast.receiver.system.DisconnectReason.REQUESTED_BY_SENDER)) {
 			castReceiverManager.stop();

--- a/modules/DoubleClick/resources/mw.DoubleClick.js
+++ b/modules/DoubleClick/resources/mw.DoubleClick.js
@@ -1465,7 +1465,7 @@
 					setTimeout(function () {
 						_this.embedPlayer.hideSpinner();
 						_this.adLoaderErrorFlag = true;
-						$(_this.embedPlayer).trigger("adErrorEvent");
+						$(_this.embedPlayer).trigger("adErrorEvent",[adInfo]);
 						_this.onAdError("adsLoadError");
 					}, 100);
 				}, 'adsLoadError', true);
@@ -1632,7 +1632,7 @@
 			var errorMsg = ( typeof errorEvent.getError != 'undefined' ) ? errorEvent.getError() : errorEvent;
 			mw.log('DoubleClick:: onAdError: ' + errorMsg );
 			if (!this.adLoaderErrorFlag){
-				$( this.embedPlayer ).trigger("adErrorEvent");
+				$( this.embedPlayer ).trigger("adErrorEvent", [errorMsg]);
 				this.adLoaderErrorFlag = true;
 			}
 			if (this.adsManager && $.isFunction( this.adsManager.unload ) ) {


### PR DESCRIPTION
Add Sender Connected count on bus

Example;
11-17 22:24:29.047 15095-15095/com.kaltura.ccplayerdemo D/KCastKalturaChannel: onMessageReceived <urn:x-cast:com.kaltura.cast.player> <chromecastReceiverAdError|AdError 1005: The provided ad type: skippablevideo is not supported.>

11-17 22:53:36.512 14664-14664/com.kaltura.ccplayerdemo D/KCastKalturaChannel: onMessageReceived <urn:x-cast:com.kaltura.cast.player> <chromecastReceiverOnSenderConnected|2>