### PR TITLE
HTML 5 PLayer Font Size Overwritten

### DIFF
--- a/modules/KalturaSupport/components/theme.js
+++ b/modules/KalturaSupport/components/theme.js
@@ -78,8 +78,10 @@
 						$(".ui-slider").attr("style","background-color: " + value + " !important");
 						break;
 					case 'controlsBkgColor':
-						$(".mwPlayerContainer:not(.mobileSkin)").find(".controlsContainer").attr("style","background-color: " + value + " !important");
-						$(".mwPlayerContainer:not(.mobileSkin)").find(".controlsContainer").attr("style","background: " + value + " !important");
+						$(".mwPlayerContainer:not(.mobileSkin)").find(".controlsContainer").css({
+							"background": value,
+							"background-color": value,
+						});
 						break;
 					case 'scrubberColor':
 						$(".mwPlayerContainer:not(.mobileSkin)").find(".playHead").attr("style","background-color: " + value + " !important");


### PR DESCRIPTION
HTML 5 PLayer Button Font Size Overwritten by controlsBkgColor due to the use of .attr('style', ...).

To replicate set the font size and background custom theme settings and then see that controlsContainer only has style="background: value".