### PR TITLE
SUP-8514 if assetId is undefined to set the thumbnail url

### DIFF
--- a/modules/KalturaSupport/resources/mw.KCuePoints.js
+++ b/modules/KalturaSupport/resources/mw.KCuePoints.js
@@ -136,6 +136,9 @@
 							data[index] = null;
 						}
 					});
+					thumbCuePoint = thumbCuePoint.filter(function(cuepoint) {
+						return (typeof(cuepoint.assetId) !== 'undefined');
+					});
 					$.each(thumbCuePoint, function (index, item) {
 						item.thumbnailUrl = loadThumbnailWithReferrer ? data[index] + '?options:referrer=' + referrer : data[index];
 					});


### PR DESCRIPTION
@OrenMe 
Let me know what you think.

the bug is happening because we have let's say 4 cuepoints, the first one is a chapter that is set to auto, the remaining three are slides with a thumbnail.
now we build an array of thumbasset to fetch, we add to the array only cuepoints with thumbasset.
we then loop through the 4 cuepoints and set its thumbnailUrl to be one of the three thumbassets we get, this is the bug. so the chapter that was set to auto, get the thumbasset of the 2nd cuepoint, 2nd slide get the 3rd, and so on.
Probably have not explained it well enough, i'll be happy to try again f2f. 

