### PR TITLE
Fixing isTimeUpdateSupported in non-dvr live streams

### DIFF
--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
@@ -565,13 +565,13 @@
 		 * Android Live doesn't send timeupdate events
 		 * @returns {boolean}
 		 */
-		isTimeUpdateSupported: function () {
-			if (this.isLive() && mw.isAndroid()) {
-				return false;
-			} else {
-				return true;
-			}
-		},
+        isTimeUpdateSupported: function () {
+            if (this.isLive() && (mw.isAndroid() || !this.isDVR())) {
+                return false;
+            } else {
+                return true;
+            }
+        },
 		/**
 		 * playerSwitchSource switches the player source working around a few bugs in browsers
 		 *


### PR DESCRIPTION
When we pressed play after back to live, mwEmbedPlayer:: play() was adding a spinner because isTimeUpdateSupported returned true.
syncCurrentTime interval never hides the spinner because currentTime always equals player time (both 0).
Seems like in non-dvr live streams time update is not relevant and for that we need to define isTimeUpdateSupported to return false in such cases.