### PR TITLE
Dual screen fixes

### DIFF
--- a/modules/KalturaSupport/components/dualScreen/display.js
+++ b/modules/KalturaSupport/components/dualScreen/display.js
@@ -37,9 +37,19 @@
 				.draggable( $.extend( this.getConfig( 'draggable' ), this.viewActionHandler() ))
 				.resizable( $.extend( this.getConfig( 'resizable' ), this.viewActionHandler() ));
 		},
-		repaint: function(screenProps){
-			this.prop = screenProps;
-			this.obj.css( screenProps );
+		repaint: function(screenProps, forceProps){
+			if (this.forcedProps && !forceProps) {
+				this.prop = this.forcedProps;
+				this.forcedProps = null;
+			} else {
+				this.prop = screenProps;
+			}
+
+			if (forceProps) {
+				this.forcedProps = screenProps;
+			}
+
+			this.obj.css(this.prop);
 			this.getPlayer().triggerHelper('displayRepainted');
 		},
 		getProperties: function(){
@@ -185,7 +195,7 @@
             this.obj.removeClass('hiddenScreen' ).addClass('firstScreen' );
         },
 		hide: function (isFlashMode) {
-            var xOffset = this.getPlayer().getWidth() - (parseInt(this.obj.css('left')) || 0) + (parseInt(this.obj.width()) || 0);
+            var xOffset = window.screen.width;
             this.obj.addClass( 'hiddenScreen' );
             this.obj.css('transform', 'translate(' + xOffset + 'px, 0)');
             //take care of flash obj (seek through hidden flash player will be very slow, so we need to bring at least several pixels inside the visible area of the player frame)

--- a/modules/KalturaSupport/components/dualScreen/dualScreen.js
+++ b/modules/KalturaSupport/components/dualScreen/dualScreen.js
@@ -150,6 +150,7 @@
 				this.bind( "hideScreen", function (e, screenName) {
 					isOverlayScreenOpen = false;
 					_this.restoreView(screenName);
+					_this.updateSecondScreenLayout(e);
 				} );
 
 				this.bind('dualScreenStreamChange', function (e, data) {
@@ -784,7 +785,7 @@
 							}
 
 							var secondScreen = _this.displays.getAuxDisplay();
-							secondScreen.repaint(screenProps);
+							secondScreen.repaint(screenProps, true);
 							if (!_this.disabled && _this.render) {
 								//Show display and control bar after resizing
 								_this.enableView();

--- a/modules/KalturaSupport/components/dualScreen/dualScreen.js
+++ b/modules/KalturaSupport/components/dualScreen/dualScreen.js
@@ -1030,28 +1030,35 @@
 				var promise;
 
 				if (mw.isMobileDevice()) {
-					var forceMosaic = this.getConfig('forceMuxedOnMobileDevices') ||
-						(mw.isIOS() && (navigator.userAgent.indexOf('iPad') === -1));
-					promise = (forceMosaic ? $.Deferred().reject() : this.initSecondPlayer(true))
-						.then(function (res) {
-							if (mobileTag) {
-								utils.setConfig({
-									streamSelectorConfig: {
-										ignoreTag: mobileTag
+					var muxedStreamsPromise = mobileTag ?
+						utils.filterStreamsByTag(mobileTag).then(null, function (streams) {
+							return [];
+						}) : [];
+					promise = $.when(muxedStreamsPromise).then(function (streams) {
+						var muxedStream = streams[0];
+						var forceMosaic = (mw.isIOS() && (navigator.userAgent.indexOf('iPad') === -1)) ||
+							(_this.getConfig('forceMuxedOnMobileDevices') && muxedStream);
+
+						return (forceMosaic ?
+							$.Deferred().reject() :
+							_this.initSecondPlayer(true))
+								.then(function (res) {
+									if (mobileTag) {
+										utils.setConfig({
+											streamSelectorConfig: {
+												ignoreTag: mobileTag
+											}
+										});
+
+										_this.updateStreams();
 									}
+
+									return res;
+								}, function () {
+									muxedStream && utils.setStream(muxedStream, forceMosaic, true);
+									return $.Deferred().reject();
 								});
-
-								_this.updateStreams();
-							}
-
-							return res;
-						}, function () {
-							mobileTag && utils.filterStreamsByTag(mobileTag).then(function (streams) {
-								utils.setStream(streams[0], forceMosaic, true);
-							});
-
-							return $.Deferred().reject();
-						});
+					});
 				} else {
 					if (mobileTag) {
 						utils.setConfig({

--- a/modules/KalturaSupport/components/dualScreen/streamUtils.js
+++ b/modules/KalturaSupport/components/dualScreen/streamUtils.js
@@ -265,7 +265,6 @@
             });
 
             this._super();
-            this.embedPlayer.unbindHelper('.streamUtilsSetStream');
         }
     });
 })(window.mw, window.jQuery);

--- a/modules/KalturaSupport/components/dualScreen/tests/index.html
+++ b/modules/KalturaSupport/components/dualScreen/tests/index.html
@@ -8,6 +8,12 @@
     <script type="text/javascript" src="../../../../../docs/js/doc-bootstrap.js"></script>
 </head>
 <body>
+<ul>
+    <li><a href="html5/">HTML5 Tests</a></li>
+    <li><a href="html5-hls/">HTML5 hls.js Tests</a></li>
+    <li><a href="flash/">Flash Tests</a></li>
+    <li><a href="hls/">Flash Hls Tests</a></li>
+</ul>
 <h1>Dual Screen Test</h1>
 <br />
 <div id="kaltura_player" style="width: 960px; height: 640px;float: left;"></div>


### PR DESCRIPTION
* FEC-6431: Lecture capture audio stream - Slides are not displayed at
all on iPad
* FEC-6436: Dual video: if open fullscreen with opened Moderation, secondary screen location is wrong