### PR TITLE
FEC-6441: Fix IVQ for DualVideo players

### DIFF
--- a/modules/KalturaSupport/components/dualScreen/dualScreen.js
+++ b/modules/KalturaSupport/components/dualScreen/dualScreen.js
@@ -79,7 +79,7 @@
 
 				var _this = this;
                 this.bind( 'playerReady', function (  ) {
-                    _this.getPlayer().triggerHelper('dualScreenLoaded');
+
                     mw.log('DualScreen - playerReady');
                     //block DualScreen for spalyer
                     if ( _this.getPlayer().instanceOf === 'Silverlight' ) {
@@ -383,6 +383,7 @@
                     this.waitForSecondScreen = null;
 
                     if (this.syncEnabled) {
+
                         var _this = this;
                         this.initView();
                         this.initControlBar();
@@ -390,6 +391,7 @@
 
                         if (_this.secondPlayer.canRender()) {
                             _this.log("render condition are met - initializing");
+                			_this.getPlayer().triggerHelper('dualScreenLoaded');
                             _this.checkRenderConditions();
                             if (_this.disabled){
                                 _this.disabled = false;

--- a/modules/KalturaSupport/components/dualScreen/dualScreen.js
+++ b/modules/KalturaSupport/components/dualScreen/dualScreen.js
@@ -315,10 +315,12 @@
 				});
 				this.bind("onChangeStream", function(){
 					_this.syncEnabled = false;
+					_this.getPlayer().triggerHelper('dualVideoOnChangeStream');
 				});
 				this.bind("onChangeStreamDone", function(){
 					_this.syncEnabled = true;
 					_this.updateStreams();
+					_this.getPlayer().triggerHelper('dualVideoOnChangeStreamDone');
 				});
 
 				if (this.getConfig('enableKeyboardShortcuts')) {

--- a/modules/KalturaSupport/components/dualScreen/dualScreen.js
+++ b/modules/KalturaSupport/components/dualScreen/dualScreen.js
@@ -315,12 +315,14 @@
 				});
 				this.bind("onChangeStream", function(){
 					_this.syncEnabled = false;
-					_this.getPlayer().triggerHelper('dualVideoOnChangeStream');
 				});
 				this.bind("onChangeStreamDone", function(){
 					_this.syncEnabled = true;
 					_this.updateStreams();
-					_this.getPlayer().triggerHelper('dualVideoOnChangeStreamDone');
+				});
+
+				this.embedPlayer.bindHelper('onChangeStream.dualScreenIvqSupport onChangeStreamDone.dualScreenIvqSupport', function (event) {
+					_this.getPlayer().triggerHelper('dualScreen_' + event.type);
 				});
 
 				if (this.getConfig('enableKeyboardShortcuts')) {

--- a/modules/KalturaSupport/components/dualScreen/dualScreen.js
+++ b/modules/KalturaSupport/components/dualScreen/dualScreen.js
@@ -76,8 +76,10 @@
 				this.getPlayer().playerConfig.plugins.playlistAPI.plugin !== false);
 			},
 			addBindings: function () {
+
 				var _this = this;
                 this.bind( 'playerReady', function (  ) {
+                    _this.getPlayer().triggerHelper('dualScreenLoaded');
                     mw.log('DualScreen - playerReady');
                     //block DualScreen for spalyer
                     if ( _this.getPlayer().instanceOf === 'Silverlight' ) {

--- a/modules/KalturaSupport/components/streamSelector.js
+++ b/modules/KalturaSupport/components/streamSelector.js
@@ -41,6 +41,9 @@
 		},
 		addBindings: function () {
 			var _this = this;
+			this.bind('dualScreenLoaded', function () {
+                _this.destroy();
+            });
 
 			this.bind('playerReady', function () {
 				if (!_this.streamsReady) {

--- a/modules/Quiz/resources/IVQApiCall.js
+++ b/modules/Quiz/resources/IVQApiCall.js
@@ -86,7 +86,7 @@
                         answerParams = {
                             'action': 'update',
                             'id': $.cpObject.cpArray[questionNr].answerCpId,
-                            'cuePoint:entryId': _this.embedPlayer.kentryid
+                            'cuePoint:entryId': $.cpObject.cpArray[questionNr].cpEntryId
                         }
                     } else {
                         answerParams = {

--- a/modules/Quiz/resources/quiz.js
+++ b/modules/Quiz/resources/quiz.js
@@ -18,7 +18,8 @@
             displayImportance: 'medium',
             templatePath: '../Quiz/resources/templates/quiz.tmpl.html',
             usePreviewPlayer: false,
-            previewPlayerEnabled: false
+            previewPlayerEnabled: false,
+            ignoreStreamChanges: false
         },
 
         isSeekingIVQ:false,
@@ -26,6 +27,7 @@
         selectedAnswer:null,
         seekToQuestionTime:null,
         multiStreamWelcomeSkip:false,
+        streamChanging:false,
         IVQVer:'IVQ-2.41.rc2',
 
         setup: function () {
@@ -38,9 +40,20 @@
             this.bind('onChangeStream', function () {
                 mw.log("Quiz: multistream On");
                 _this.multiStreamWelcomeSkip = true;
+                _this.streamChanging = true;
+            });
+            this.bind('onChangeStreamDone', function () {
+                _this.streamChanging = false;
             });
 
             embedPlayer.addJsListener( 'kdpReady', function(){
+                // [FEC-6441: Quiz plugin damaged when switching between dual video options]
+                // Don't reload quiz cuepoints when a stream change occurs
+                // Needed for the dual-video cases in which only the parent media contains quiz metadata
+                if (_this.getConfig('ignoreStreamChanges') && _this.streamChanging) {
+                    return;
+                }
+
                 _this.KIVQModule = new mw.KIVQModule(embedPlayer, _this);
                 _this.KIVQModule.isKPlaylist = (typeof (embedPlayer.playlist) === "undefined" ) ? false : true;
 

--- a/modules/Quiz/resources/quiz.js
+++ b/modules/Quiz/resources/quiz.js
@@ -163,8 +163,14 @@
             });
 
             embedPlayer.bindHelper('seeked'+_this.KIVQModule.bindPostfix, function () {
-               _this.isSeekingIVQ = false;
-                mw.log("Quiz: Seeked");
+                // KMS-13599
+                // Let the mw.KCuePoints 'seeked' handler run before
+                // in order to make sure that the KalturaSupport_CuePointReached handler
+                // is not called before the player finished seeking
+                setTimeout(function () {
+                    _this.isSeekingIVQ = false;
+                    mw.log("Quiz: Seeked");
+                }, 0);
             });
 
             embedPlayer.bindHelper('seeking'+_this.KIVQModule.bindPostfix, function () {

--- a/modules/Quiz/resources/quiz.js
+++ b/modules/Quiz/resources/quiz.js
@@ -18,8 +18,7 @@
             displayImportance: 'medium',
             templatePath: '../Quiz/resources/templates/quiz.tmpl.html',
             usePreviewPlayer: false,
-            previewPlayerEnabled: false,
-            ignoreStreamChanges: false
+            previewPlayerEnabled: false
         },
 
         isSeekingIVQ:false,
@@ -27,7 +26,7 @@
         selectedAnswer:null,
         seekToQuestionTime:null,
         multiStreamWelcomeSkip:false,
-        streamChanging:false,
+        relatedStreamChanging:false,
         IVQVer:'IVQ-2.41.rc2',
 
         setup: function () {
@@ -40,17 +39,19 @@
             this.bind('onChangeStream', function () {
                 mw.log("Quiz: multistream On");
                 _this.multiStreamWelcomeSkip = true;
-                _this.streamChanging = true;
             });
-            this.bind('onChangeStreamDone', function () {
-                _this.streamChanging = false;
+            this.bind('dualVideoOnChangeStream', function () {
+                _this.relatedStreamChanging = true;
+            });
+            this.bind('dualVideoOnChangeStreamDone', function () {
+                _this.relatedStreamChanging = false;
             });
 
             embedPlayer.addJsListener( 'kdpReady', function(){
                 // [FEC-6441: Quiz plugin damaged when switching between dual video options]
                 // Don't reload quiz cuepoints when a stream change occurs
                 // Needed for the dual-video cases in which only the parent media contains quiz metadata
-                if (_this.getConfig('ignoreStreamChanges') && _this.streamChanging) {
+                if (_this.relatedStreamChanging) {
                     return;
                 }
 

--- a/modules/Quiz/resources/quiz.js
+++ b/modules/Quiz/resources/quiz.js
@@ -165,8 +165,8 @@
             embedPlayer.bindHelper('seeked'+_this.KIVQModule.bindPostfix, function () {
                 // KMS-13599
                 // Let the mw.KCuePoints 'seeked' handler run before
-                // in order to make sure that the KalturaSupport_CuePointReached handler
-                // is not called before the player finished seeking
+                // in order to make sure that the 'KalturaSupport_CuePointReached' event,
+                // triggered by the 'seeked' event, is not handled by the plugin
                 setTimeout(function () {
                     _this.isSeekingIVQ = false;
                     mw.log("Quiz: Seeked");

--- a/modules/Quiz/resources/quiz.js
+++ b/modules/Quiz/resources/quiz.js
@@ -40,10 +40,10 @@
                 mw.log("Quiz: multistream On");
                 _this.multiStreamWelcomeSkip = true;
             });
-            this.bind('dualVideoOnChangeStream', function () {
+            this.bind('dualScreen_onChangeStream', function () {
                 _this.relatedStreamChanging = true;
             });
-            this.bind('dualVideoOnChangeStreamDone', function () {
+            this.bind('dualScreen_onChangeStreamDone', function () {
                 _this.relatedStreamChanging = false;
             });
 


### PR DESCRIPTION
Don't reload quiz cuepoints when a stream change occurs
Needed for the dual-video cases in which only the parent media contains
quiz metadata