### PR TITLE
Fix FEC-6462

### DIFF
--- a/modules/KalturaSupport/components/dualScreen/dualScreenControlBar.js
+++ b/modules/KalturaSupport/components/dualScreen/dualScreenControlBar.js
@@ -70,7 +70,9 @@
                     if (dragDropEnabled) {
                         $stream.draggable({
                             revert: true,
-                            helper: 'clone',
+                            helper: function (event) {
+                                return $(this).clone().css('position', 'absolute').get(0);
+                            },
                             containment: '.videoHolder',
                             start: function (event, ui) {
                                 $(ui.helper).addClass('ds-stream--helper');


### PR DESCRIPTION
FEC-6462: DualScreen - on Safari dragging an item has an offset
* Make the helper absolutely positioned in order to prevent the parent
container to grow