### PR TITLE
SUP-11300 Playlist Infinite load wheel with showThumbnailWhenOffline …

### DIFF
--- a/modules/KalturaSupport/components/live/liveCore.js
+++ b/modules/KalturaSupport/components/live/liveCore.js
@@ -245,6 +245,8 @@
                             _this.playWhenOnline = embedPlayer.isPlaying();
 
                             if (_this.getConfig('showThumbnailWhenOffline')) {
+								embedPlayer.hideSpinner();
+								mw.setConfig('EmbedPlayer.HidePosterOnStart', false);
                                 _this.addPoster();
                             } else {
                                 embedPlayer.layoutBuilder.displayAlert({


### PR DESCRIPTION
…on live entry with DVR

In the playlistAPI we set HidePosterOnStart to true, when the showThumbnailWhenOffline is set in the config. The updatePosterHTML this condition is true http://tinyurl.com/y8e2jex6 and we never show the poster. 

Also need to hide the spinner and I check that it works with a single entry.