### PR TITLE
Sup 9616 default language key var not passed to apple AVplayer

### DIFF
--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
@@ -618,7 +618,7 @@
 		 */
 		selectDefaultCaption: function (defaultLangKey) {
 			var textTracks = this.getPlayerElement().textTracks;
-			if (this.isTextTrackSelected(textTracks)) {
+			if (this.isTextTrackSelected(textTracks, defaultLangKey)) {
 				return true;
 			}
 			this.showDefaultTextTrack(textTracks, defaultLangKey);
@@ -630,9 +630,9 @@
 		 *             Text tracks array.
 		 * @returns {boolean}
 		 */
-		isTextTrackSelected: function (textTracks) {
+		isTextTrackSelected: function (textTracks, defaultLangKey) {
 			for (var i=0; textTracks.length > i; i++) {
-				if (textTracks[i].mode == "showing") {
+				if (textTracks[i].mode === "showing" && textTracks[i].language === defaultLangKey) {
 					return true;
 				}
 			}
@@ -648,7 +648,10 @@
 		 */
 		showDefaultTextTrack: function (textTracks, defaultLangKey) {
 			$.each( textTracks, function( inx, caption) {
-				if (caption.language == defaultLangKey) {
+				caption.mode = "hidden";
+			});
+			$.each( textTracks, function( inx, caption) {
+				if (caption.language === defaultLangKey) {
 					caption.mode = "showing";
 				}
 			});


### PR DESCRIPTION
@OrenMe Sat with Dan and we fixed the logic of the selectDefaultCaption, it would set a CC track to showing and we had 2 CC tracks in showing state (The other one is from the AV player when a user selects a CC) so it would not show any CC.