### PR TITLE
SUP-11400 other keyboard shortcuts override video360 keyboard shortcuts

### DIFF
--- a/modules/KalturaSupport/components/dualScreen/dualScreen.js
+++ b/modules/KalturaSupport/components/dualScreen/dualScreen.js
@@ -371,10 +371,12 @@
 					}
 					_this.getPlayer().triggerHelper('dualScreenStateChange', action);
 				});
-				// Add w Sigh for switch view
-				addKeyCallback(this.getConfig("keyboardShortcutsMap").switchView, function () {
-					_this.getPlayer().triggerHelper('dualScreenStateChange', "switchView");
-				});
+				// Add w Sigh for switch view, with video360 this is not enabled as it blocks the keyboard shortcuts
+				if ( !_this.getPlayer().playerConfig.plugins.video360.plugin ) {
+					addKeyCallback(this.getConfig("keyboardShortcutsMap").switchView, function () {
+						_this.getPlayer().triggerHelper('dualScreenStateChange', "switchView");
+					});
+				}
 			},
             renderDualScreenView: function(){
                 if( this.secondPlayer ) {

--- a/modules/KalturaSupport/components/streamSelector.js
+++ b/modules/KalturaSupport/components/streamSelector.js
@@ -213,14 +213,16 @@
 				_this.setStream(_this.getDefaultStream());
 				_this.setActiveMenuItem();
 			});
-			// Add S Sigh for open menu
-			addKeyCallback(this.getConfig("keyboardShortcutsMap" ).openMenu, function () {
-				_this.getMenu().open();
-			});
-			// Add Shift+S Sigh for close menu
-			addKeyCallback(this.getConfig("keyboardShortcutsMap" ).closeMenu, function () {
-				_this.getMenu().close();
-			});
+			if ( !_this.getPlayer().playerConfig.plugins.video360.plugin ) {
+				// Add S Sigh for open menu
+				addKeyCallback(this.getConfig("keyboardShortcutsMap" ).openMenu, function () {
+					_this.getMenu().open();
+				});
+				// Add Shift+S Sigh for close menu
+				addKeyCallback(this.getConfig("keyboardShortcutsMap" ).closeMenu, function () {
+					_this.getMenu().close();
+				});
+			}
 		},
 		getNextStream: function () {
 			if (this.streams[this.getCurrentStreamIndex() + 1]) {


### PR DESCRIPTION
@OrenMe Need to get approval from Karin if this is the fix she wants to do, will update when I get an answer from her.

The fix here is to not ad the keyboard shortcuts from stream selector and dual screen with 360 video.