### PR TITLE
Cache entry data by protocol(SUP-11246)

### DIFF
--- a/modules/KalturaSupport/EntryResult.php
+++ b/modules/KalturaSupport/EntryResult.php
@@ -116,7 +116,8 @@ class EntryResult
 
     function getCacheKey()
     {
-        global $wgForceCache;
+        //Cache by entryId and protocol
+        global $wgForceCache, $wgHTTPProtocol;
         $key = '';
         if ($this->request->isEmbedServicesEnabled() && $this->request->isEmbedServicesRequest()) {
             if ($wgForceCache) {
@@ -136,6 +137,7 @@ class EntryResult
         if ($this->request->getReferenceId()) {
             $key .= $this->request->getReferenceId();
         }
+        $key .= ".".$wgHTTPProtocol;
         return $key;
     }
 


### PR DESCRIPTION
Cache is done by entryId, but response from API depends on protocol as
well, so need to add cache by protocol as well as entry Id