### PR TITLE
fix(FEC-7049): YT playback fails when ad load fails and there's autoplay

### DIFF
--- a/modules/ExternalPlayers/resources/mw.EmbedPlayerYouTube.js
+++ b/modules/ExternalPlayers/resources/mw.EmbedPlayerYouTube.js
@@ -671,7 +671,13 @@
 		 * Get the embed player time
 		 */
 		getPlayerElementTime : function(){
-			return this.getPlayerElement().getCurrentTime();
+			var playerElement = this.getPlayerElement();
+			var time = 0;
+			//If YT API player is not loaded yet then return 0
+			if (playerElement && playerElement.getCurrentTime) {
+                time = playerElement.getCurrentTime();
+            }
+            return time;
 		},
 
 		/**


### PR DESCRIPTION
When YoutUbe player is loaded it takes time until YT player API is loaded.
If we have ad configured and it fails to load then the player tries to continue the playback on the player.
Due to timing issues the YT player API might not be ready yet and then the call to getCurrentTime on it fails and it blows up the player.
Test page: http://www.radio24.ch/events/mark-forster-131346703
fixes #3494