### PR TITLE
SUP-11400 Change dual screen and stream selector keyboardShortcutsMap

### DIFF
--- a/modules/KalturaSupport/components/dualScreen/dualScreen.js
+++ b/modules/KalturaSupport/components/dualScreen/dualScreen.js
@@ -42,8 +42,8 @@
 				"minDisplayHeight": 0,
 				"enableKeyboardShortcuts": true,
 				"keyboardShortcutsMap": {
-					"nextState": 81,   // Add q Sign for next state
-					"switchView": 87   // Add w Sigh for switch views
+					"nextState": 90,   // Add q Sign for next state
+					"switchView": 88   // Add w Sigh for switch views
 				}
 			},
 			display: {},

--- a/modules/KalturaSupport/components/dualScreen/dualScreen.js
+++ b/modules/KalturaSupport/components/dualScreen/dualScreen.js
@@ -42,8 +42,8 @@
 				"minDisplayHeight": 0,
 				"enableKeyboardShortcuts": true,
 				"keyboardShortcutsMap": {
-					"nextState": 90,   // Add q Sign for next state
-					"switchView": 88   // Add w Sigh for switch views
+					"nextState": 90,   // Add z Sign for next state
+					"switchView": 88   // Add x Sigh for switch views
 				}
 			},
 			display: {},

--- a/modules/KalturaSupport/components/streamSelector.js
+++ b/modules/KalturaSupport/components/streamSelector.js
@@ -21,8 +21,6 @@
 				"nextStream": 221,   // Add ] Sign for next stream
 				"prevStream": 219,   // Add [ Sigh for previous stream
 				"defaultStream": 220, // Add \ Sigh for default stream
-				"openMenu": 83, // Add S Sigh for open menu
-				"closeMenu": "shift+83" // Add Shift+S Sigh for close menu
 			}
 		},
 


### PR DESCRIPTION
@eitanavgil I talked with Karin about the keyboardShortcutsMap override and she said to remove the open close menu for the stream selector and to change the 'next state' and 'switch views' to 'z' and 'x'