### PR TITLE
SUP-11568 Playlist controls are disabled when switching from Live to VOD

### DIFF
--- a/modules/DoubleClick/resources/mw.DoubleClick.js
+++ b/modules/DoubleClick/resources/mw.DoubleClick.js
@@ -93,6 +93,9 @@
         adCuePoints: [],
         skipTimeoutId: null,
         chromelessAdManagerLoadedId: null,
+        
+        //Turn on to disable ads if live stream entry is offline
+        disablePlaylistAdsOnLiveStream: false,
 
         init: function ( embedPlayer, callback, pluginName ) {
             if ( embedPlayer.casting || mw.getConfig( "EmbedPlayer.UseExternalAdPlayer" ) === true ) {
@@ -885,7 +888,9 @@
         },
         // This function requests the ads.
         requestAds: function ( adType ) {
-            if ( !this.adTagUrl ) {
+            //Add a flag to disable ads if live stream entry is offline
+            if ( !this.adTagUrl || ( this.getConfig( "disablePlaylistAdsOnLiveStream" ) === true && this.embedPlayer.isPlaylistScreen()
+                && this.embedPlayer.isLive() && this.embedPlayer.isOffline() ) ) {
                 if ( $.isFunction( this.restorePlayerCallback ) ) {
                     this.restorePlayerCallback();
                 }

--- a/modules/DoubleClick/resources/mw.DoubleClick.js
+++ b/modules/DoubleClick/resources/mw.DoubleClick.js
@@ -94,7 +94,7 @@
         skipTimeoutId: null,
         chromelessAdManagerLoadedId: null,
         
-        //Turn on to disable ads if live stream entry is offline
+        //Turn on to disable ads if live stream entry is offline inside a playlist
         disablePlaylistAdsOnLiveStream: false,
 
         init: function ( embedPlayer, callback, pluginName ) {
@@ -888,7 +888,6 @@
         },
         // This function requests the ads.
         requestAds: function ( adType ) {
-            //Add a flag to disable ads if live stream entry is offline
             if ( !this.adTagUrl || ( this.getConfig( "disablePlaylistAdsOnLiveStream" ) === true && this.embedPlayer.isPlaylistScreen()
                 && this.embedPlayer.isLive() && this.embedPlayer.isOffline() ) ) {
                 if ( $.isFunction( this.restorePlayerCallback ) ) {

--- a/modules/KalturaSupport/components/playlistAPI.js
+++ b/modules/KalturaSupport/components/playlistAPI.js
@@ -492,13 +492,14 @@
 						embedPlayer.play();
 					},500); // timeout is required when loading live entries
 				}
-
 				if (mw.isMobileDevice() && !mobileAutoPlay){
 					mw.setConfig('EmbedPlayer.HidePosterOnStart', false);
 					embedPlayer.updatePosterHTML();
 				}
 			});
 			mw.log("PlaylistAPI::playClip::changeMedia entryId: " + id);
+			//Need to enable the controls if the previous entry was an offline live stream, Livecore.js handles the controls logic for live stream entries.
+			this.getPlayer().enablePlayControls();
 
 			if (!this.firstPlay && this.getConfig('hideClipPoster') === true && !mw.isIphone()) {
 				mw.setConfig('EmbedPlayer.HidePosterOnStart', true);


### PR DESCRIPTION
@OrenMe  Tried to use the 'liveStreamStatusUpdate' from liveCore but it does not cover the issue with ads, I checked with an offlive/online && ads/no ads and it all works as expected.