### PR TITLE
SUP-11568 Playlist controls are disabled when switching from VOD to live

### DIFF
--- a/modules/KalturaSupport/components/playlistAPI.js
+++ b/modules/KalturaSupport/components/playlistAPI.js
@@ -498,6 +498,8 @@
 				}
 			});
 			mw.log("PlaylistAPI::playClip::changeMedia entryId: " + id);
+			//Need to enable the controls if the previous entry was an offline live stream, liveCore.js handles the controls logic for live stream entries.
+			this.getPlayer().enablePlayControls();
 
 			if (!this.firstPlay && this.getConfig('hideClipPoster') === true && !mw.isIphone()) {
 				mw.setConfig('EmbedPlayer.HidePosterOnStart', true);


### PR DESCRIPTION
@OrenMe Confirmed that TR do not use ads so we do not need to address that issue now, they are the only customer who uses live stream with playlist player.