### PR TITLE
[Rapt Media] Improve autoplay and poster display

### DIFF
--- a/modules/RaptMedia/resources/mw.RaptMedia.js
+++ b/modules/RaptMedia/resources/mw.RaptMedia.js
@@ -172,6 +172,9 @@
 			// Attempt to prevent the last segment from incorrectly triggering ended / replay behavior
 			this.getPlayer().onDoneInterfaceFlag = false;
 
+			// Keep the poster around until playback begins
+			mw.setConfig('EmbedPlayer.KeepPoster', true);
+
 			$.when(
 				this.loadEngine(),
 				this.loadSegments(raptProjectId)
@@ -217,6 +220,8 @@
 			}
 
 			this.initialize();
+
+			mw.setConfig('EmbedPlayer.KeepPoster', false);
 
 			// Re-enable ended / replay behavior
 			this.getPlayer().onDoneInterfaceFlag = true;
@@ -485,9 +490,14 @@
 				load: function(media, flags) {
 					var entryId = media.sources[0].src;
 					var nextSegment = _this.segments[entryId];
+					var stopAfterSeek = true;
+
+					if (_this.getConfig('status') === 'loading') {
+						stopAfterSeek = undefined;
+					}
 
 					if (nextSegment) {
-						_this.seek(nextSegment, 0, true);
+						_this.seek(nextSegment, 0, stopAfterSeek);
 					} else {
 						_this.fatal(
 							'Error in RAPT playback',
@@ -516,6 +526,10 @@
 					switch (event.type) {
 						case 'project:ended':
 							// TODO: Trigger end screen
+							break;
+						case 'project:start':
+							mw.setConfig('EmbedPlayer.KeepPoster', false);
+							_this.getPlayer().removePoster();
 							break;
 					}
 


### PR DESCRIPTION
Attempt to fix autoplay issues with Rapt Media interactive videos.

- During the initial seek (trigger by "loading" the initial media) prevent the default stopAfterSeek and allow the player to use it's default behavior.
- Prevent hiding of the poster from the initial "loading" seek.

Known Issues:
- The player seems to trigger the `checkPlayerSourcesEvent` _before_ loading the Rapt Media plugin. This means the player doesn't properly wait for the engine to be ready before beginning playback. On slow connections this can cause a stutter at the beginning of playback. It may be causing further race conditions or hiding other issues.