### PR TITLE
fix(SUP-12496): ad noticeMessage appears only for preroll

### DIFF
--- a/modules/DoubleClick/resources/mw.DoubleClick.js
+++ b/modules/DoubleClick/resources/mw.DoubleClick.js
@@ -1253,6 +1253,7 @@
                 if ( _this.isLinear ) {
                     if ( !_this.adSkippable ) {
                         _this.showSkipBtn();
+                        _this.addCountdownNotice();
                     }
                     _this.playingLinearAd = true;
                     // hide spinner:

--- a/modules/DoubleClick/resources/mw.DoubleClick.js
+++ b/modules/DoubleClick/resources/mw.DoubleClick.js
@@ -730,7 +730,6 @@
                             'left': '0px'
                         } )
                 );
-                this.addCountdownNotice();
             }
             return $( '#' + this.getAdContainerId() ).get( 0 );
         },


### PR DESCRIPTION
@OrenMe  Please review PR, The noticeMessage only appears for preroll and now it will show for all ads. I confirmed on my end that it works with pre mid and post.