### PR TITLE
feat: only throw critical Shaka errors

### DIFF
--- a/modules/Dash/resources/dash.js
+++ b/modules/Dash/resources/dash.js
@@ -470,6 +470,12 @@
 		onErrorEvent: function (event) {
             // Extract the shaka.util.Error object from the event.
             var error = event && event.detail;
+            try {
+                var errorString = JSON.stringify(error, null, "\t");
+                this.log("error: " + errorString);
+			} catch (e){
+                this.log("error: unable to stringify Shaka error");
+			}
             //Only throw critical error
 			if (error &&
 				error.severity &&

--- a/modules/Dash/resources/dash.js
+++ b/modules/Dash/resources/dash.js
@@ -468,8 +468,14 @@
 		},
 
 		onErrorEvent: function (event) {
-			// Extract the shaka.util.Error object from the event.
-			this.onError(event.detail);
+            // Extract the shaka.util.Error object from the event.
+            var error = event && event.detail;
+            //Only throw critical error
+			if (error &&
+				error.severity &&
+				error.severity === shaka.util.Error.Severity.CRITICAL) {
+                this.onError(error);
+            }
 		},
 
 		/**


### PR DESCRIPTION
throwing recovarable errors causes player UI to show error message although Shaka can still recover