### PR TITLE
Fix audio selector icon drops down when clicked

### DIFF
--- a/modules/KalturaSupport/components/audioSelector.js
+++ b/modules/KalturaSupport/components/audioSelector.js
@@ -233,7 +233,7 @@
 		getComponent: function () {
 			var _this = this;
 			if (!this.$el) {
-				var $menu = $('<ul />');
+				var $menu = $('<ul />').addClass('dropdown-menu');
 				//TODO: need icon from Shlomit!
 				var $button = $('<button />')
 					.addClass('btn icon-audio')


### PR DESCRIPTION
#### Select audio button (Multiple audio tracks) drops down when selected
* Add the `dropdown-menu` class to the menu element