### PR TITLE
fix(FEC-6644): after midroll first frame of the video is shown instead of continuing from the stopping point

### DIFF
--- a/modules/DoubleClick/resources/mw.DoubleClick.js
+++ b/modules/DoubleClick/resources/mw.DoubleClick.js
@@ -997,9 +997,7 @@
             mw.log( 'DoubleClick:: onAdsManagerLoaded' );
 
             var adsRenderingSettings = new google.ima.AdsRenderingSettings();
-            if ( !this.adTagUrl ) {
-                adsRenderingSettings.restoreCustomPlaybackStateOnAdBreakComplete = true; // for manual VAST, get the SDK to restore the player
-            }
+            adsRenderingSettings.restoreCustomPlaybackStateOnAdBreakComplete = true;
             if ( this.getConfig( 'enableCountDown' ) === true ) {
                 adsRenderingSettings[ "uiElements" ] = [];
             }


### PR DESCRIPTION
Always let the IMA SDK to restoreCustomPlaybackStateOnAdBreakComplete