### PR TITLE
fix(FEC-7725): parse native tracks on loadedmetadata event

### DIFF
--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
@@ -168,9 +168,6 @@
                 });
             }
 
-            this.bindHelper('firstPlay' + this.bindPostfix, function () {
-                _this.parseTracks();
-            });
             this.bindHelper('switchAudioTrack' + this.bindPostfix, function (e, data) {
                 _this.switchAudioTrack(data.index);
             });
@@ -1323,6 +1320,7 @@
 		 */
 		_onloadedmetadata: function () {
 			this.getPlayerElement();
+            this.parseTracks();
 			// only update duration if we don't have one: ( some browsers give bad duration )
 			// like Android 4 default browser
 			if (!this.duration


### PR DESCRIPTION
This will be part of 2.66, do not merge to 2.65!