### PR TITLE
fix(SUP-13105): Rebuild CC menu on change media with external CC

### DIFF
--- a/modules/KalturaSupport/resources/mw.ClosedCaptions.js
+++ b/modules/KalturaSupport/resources/mw.ClosedCaptions.js
@@ -83,6 +83,12 @@
 			}
 
 			if ( this.getConfig('showEmbeddedCaptions') === true ) {
+                this.bind( 'playerReady', function () {
+                    _this.destory();
+                    _this.setupTextSources( function () {
+                        _this.buildMenu( _this.textSources );
+                    } );
+                } );
 
 				if ( this.getConfig('showEmbeddedCaptionsStyle') === true ) {
 					this.bind( 'textTrackIndexChanged', function( e, captionData ) {

--- a/modules/KalturaSupport/resources/mw.ClosedCaptions.js
+++ b/modules/KalturaSupport/resources/mw.ClosedCaptions.js
@@ -84,10 +84,7 @@
 
 			if ( this.getConfig('showEmbeddedCaptions') === true ) {
                 this.bind( 'playerReady', function () {
-                    _this.destory();
-                    _this.setupTextSources( function () {
-                        _this.buildMenu( _this.textSources );
-                    } );
+                    _this.updateCaptionsMenu();
                 } );
 
 				if ( this.getConfig('showEmbeddedCaptionsStyle') === true ) {
@@ -132,10 +129,7 @@
 				});
 				if (!this.getConfig("useExternalClosedCaptions")) {
 					this.bind( 'playerReady', function () {
-						_this.destory();
-						_this.setupTextSources( function () {
-							_this.buildMenu( _this.textSources );
-						} );
+                        _this.updateCaptionsMenu();
 					} );
 					outOfBandCaptionEventHandlers.call(this);
 				}
@@ -366,6 +360,13 @@
 			}
 			this._super( property, value );
 		},
+		updateCaptionsMenu: function () {
+			var _this = this;
+            _this.destory();
+            _this.setupTextSources( function () {
+                _this.buildMenu( _this.textSources );
+            } );
+        },
 		hideCaptions: function(){
 			if( !this.getConfig('displayCaptions') || this.textSources.length === 0 ) {
 				if (this.getConfig('showOffButton')){

--- a/modules/KalturaSupport/resources/mw.ClosedCaptions.js
+++ b/modules/KalturaSupport/resources/mw.ClosedCaptions.js
@@ -126,7 +126,10 @@
 				});
 				if (!this.getConfig("useExternalClosedCaptions")) {
 					this.bind( 'playerReady', function () {
-                        _this.updateCaptionsMenu();
+                        _this.destory();
+                        _this.setupTextSources( function () {
+                            _this.buildMenu( _this.textSources );
+                        } );
 					} );
 					outOfBandCaptionEventHandlers.call(this);
 				}
@@ -260,7 +263,7 @@
 			});
 			this.bind( 'onChangeMedia', function (e, stylesObj){
 				//Reset UI state on change media
-				_this.updateCaptionsMenu();
+                _this.destory();
 				_this.getBtn().show();
 			});
 			this.bind( 'onOpenFullScreen', function (){
@@ -358,13 +361,6 @@
 			}
 			this._super( property, value );
 		},
-		updateCaptionsMenu: function () {
-			var _this = this;
-            _this.destory();
-            _this.setupTextSources( function () {
-                _this.buildMenu( _this.textSources );
-            } );
-        },
 		hideCaptions: function(){
 			if( !this.getConfig('displayCaptions') || this.textSources.length === 0 ) {
 				if (this.getConfig('showOffButton')){

--- a/modules/KalturaSupport/resources/mw.ClosedCaptions.js
+++ b/modules/KalturaSupport/resources/mw.ClosedCaptions.js
@@ -83,9 +83,6 @@
 			}
 
 			if ( this.getConfig('showEmbeddedCaptions') === true ) {
-                this.bind( 'playerReady', function () {
-                    _this.updateCaptionsMenu();
-                } );
 
 				if ( this.getConfig('showEmbeddedCaptionsStyle') === true ) {
 					this.bind( 'textTrackIndexChanged', function( e, captionData ) {
@@ -263,6 +260,7 @@
 			});
 			this.bind( 'onChangeMedia', function (e, stylesObj){
 				//Reset UI state on change media
+				_this.updateCaptionsMenu();
 				_this.getBtn().show();
 			});
 			this.bind( 'onOpenFullScreen', function (){


### PR DESCRIPTION
@OrenMe Please review PR, adding the destroy to the onChangeMedia did not work.
