### PR TITLE
fix: detect if kAnalony is active

### DIFF
--- a/modules/KalturaSupport/resources/mw.KAnalytics.js
+++ b/modules/KalturaSupport/resources/mw.KAnalytics.js
@@ -212,9 +212,8 @@ mw.KAnalytics.prototype = {
 			eventRequest[ 'event:' + i] = eventSet[i];
 		}
 
-		var kanalonyConfig = this.embedPlayer.getKalturaConfig( 'kAnalony' );
 		eventRequest['hasKanalony'] = false;
-		if (kanalonyConfig && kanalonyConfig.plugin && kanalonyConfig.plugin != false) {
+		if (this.embedPlayer.plugins && this.embedPlayer.plugins.kAnalony) {
 			eventRequest['hasKanalony'] = true;
 		}
 


### PR DESCRIPTION
the best way to know in the player if a plugin is active is to verify that the plugins container contains the class instance, otherwise it's undefined