### PR TITLE
fix(SUP-13081): Playlist secure embed not working when include in lay…

### DIFF
--- a/modules/KalturaSupport/resources/mw.KBaseMediaList.js
+++ b/modules/KalturaSupport/resources/mw.KBaseMediaList.js
@@ -240,7 +240,6 @@
 				this.getComponent().height(this.getConfig("mediaItemHeight") + this.getConfig('horizontalHeaderHeight'));
 			}
 			if (this.getConfig('onPage') && this.getLayout() === "vertical" && !this.getConfig("clipListTargetId")){
-				var iframeParent = window['parent'].document.getElementById( this.embedPlayer.id );
 				$( this.$mediaListContainer ).height(this.getConfig("MinClips") * this.getConfig( "mediaItemHeight" ) + this.getConfig('verticalHeaderHeight'));
 			}
 		},


### PR DESCRIPTION
…out false

@OrenMe Showed this to Itay and he confirmed to remove the iframeParent since it is not in use.