### PR TITLE
fix(chromecast): proxyData getter

### DIFF
--- a/modules/Chromecast/resources/sender/mw.EmbedPlayerChromecast.js
+++ b/modules/Chromecast/resources/sender/mw.EmbedPlayerChromecast.js
@@ -605,7 +605,7 @@
 
         getProxyData: function () {
             mw.log( "EmbedPlayerChromecast:: getProxyData" );
-            var proxyData = this.getConfig( "proxyData" );
+            var proxyData = this.getKalturaConfig("chromecast", "proxyData" );
             if ( proxyData ) {
                 var _this = this;
                 var recursiveIteration = function ( object ) {


### PR DESCRIPTION
We want to check for proxyData value of the chromecast plugin config, 
but `getConfig` of mw.EmbedPlayerChromecast caused an error since it does not have `getConfig` API (this is not a plugin).
Instead, I'm using `getKalturaConfig` API to query the proxyData value of the chromecast plugin config.