### PR TITLE
operator is not valid for PHP string concatenation

### DIFF
--- a/modules/KalturaSupport/EntryResult.php
+++ b/modules/KalturaSupport/EntryResult.php
@@ -50,7 +50,7 @@ class EntryResult
             return $this->responseHeaders;
         }
         // else cache for cache key save time:
-        $saveTime = $this->cache->get($this->getCacheKey() + '_savetime');
+        $saveTime = $this->cache->get($this->getCacheKey() . '_savetime');
         if (!$saveTime) {
             $saveTime = time();
         }
@@ -88,7 +88,7 @@ class EntryResult
             // we never cache admin or ks users access so would never expose info that not defined across anonymous regional access.
             if ($this->isCachable()) {
                 $this->cache->set($this->getCacheKey(), serialize($this->entryResultObj));
-                $this->cache->set($this->getCacheKey() + '_savetime', time());
+                $this->cache->set($this->getCacheKey() . '_savetime', time());
             }
         }
         // check if we have errors on the entry


### PR DESCRIPTION
Causes immediate invalidation of every entry object in cache for every request.
Validated both with on disk and memcache cache backend