### PR TITLE
fix(SUP-13649): Flag to add Crossorigin to player iframe

### DIFF
--- a/modules/EmbedPlayer/resources/mw.MediaElement.js
+++ b/modules/EmbedPlayer/resources/mw.MediaElement.js
@@ -579,7 +579,7 @@ mw.MediaElement.prototype = {
 					if ( !mw.isIE8() ) {
 						var $vid = $( '#pid_' + this.parentEmbedId );
 						if( $vid.length ) {
-							if( mw.isIphone() ) {
+							if( mw.isIphone() || mw.getConfig('Kaltura.addCrossoriginToIframe') === true ) {
 								$vid.attr('crossorigin', 'anonymous');
 							}
 							$vid.append(element);


### PR DESCRIPTION
@OrenMe Please review PR for 2.68, I made the fix as a flag since only a few customers complained about this, as a flag it is a less risky then to add it to everyone and then run into customer's that have manifest that do not have cors-headers and then the playback will not work.