### PR TITLE
fix(SUP-13714): Disable below layout with embedded CC

### DIFF
--- a/modules/KalturaSupport/resources/mw.ClosedCaptions.js
+++ b/modules/KalturaSupport/resources/mw.ClosedCaptions.js
@@ -83,6 +83,8 @@
 			}
 
 			if ( this.getConfig('showEmbeddedCaptions') === true ) {
+				//Set CC layout to ontop with embedded captions as it dose not use the allocated space for below CC
+                this.setConfig('layout', "ontop" );
 
 				if ( this.getConfig('showEmbeddedCaptionsStyle') === true ) {
 					this.bind( 'textTrackIndexChanged', function( e, captionData ) {
@@ -886,7 +888,7 @@
 		},
 		updateBelowVideoCaptionContainer: function(){
 			var _this = this;
-			mw.log( "TimedText:: updateBelowVideoCaptionContainer" );
+			mw.log( "ClosedCaptions:: updateBelowVideoCaptionContainer" );
 			if (this.getConfig('displayCaptions') === false){
 				return;
 			}


### PR DESCRIPTION
@OrenMe Please review for 2.68, There is no need for layout below with embedded CC as they do not use the allocated space and they are added to the shadow DOM.