### PR TITLE
[RaptMedia] Hide large play during RaptMedia project playback

### DIFF
--- a/modules/RaptMedia/resources/RaptMediaPlugin.css
+++ b/modules/RaptMedia/resources/RaptMediaPlugin.css
@@ -4,3 +4,8 @@
 	top: 0;
 	left: 0;
 }
+
+.rapt-media-running .liveStatus,
+.rapt-media-running .largePlayBtn {
+	display: none !important;
+}

--- a/modules/RaptMedia/resources/RaptMediaPlugin.css
+++ b/modules/RaptMedia/resources/RaptMediaPlugin.css
@@ -5,7 +5,6 @@
 	left: 0;
 }
 
-.rapt-media-running .liveStatus,
-.rapt-media-running .largePlayBtn {
+.raptMediaRunning .largePlayBtn {
 	display: none !important;
 }

--- a/modules/RaptMedia/resources/mw.RaptMedia.js
+++ b/modules/RaptMedia/resources/mw.RaptMedia.js
@@ -169,6 +169,8 @@
 			this.setConfig('status', 'loading', true);
 			this.setConfig('projectId', raptProjectId, true);
 
+			this.getPlayer().getInterface().removeClass('rapt-media-running');
+
 			// Attempt to prevent the last segment from incorrectly triggering ended / replay behavior
 			this.getPlayer().onDoneInterfaceFlag = false;
 
@@ -529,6 +531,7 @@
 							break;
 						case 'project:start':
 							mw.setConfig('EmbedPlayer.KeepPoster', false);
+							_this.getPlayer().getInterface().addClass('rapt-media-running'); // class to control styling during rapt playback
 							_this.getPlayer().removePoster();
 							break;
 					}

--- a/modules/RaptMedia/resources/mw.RaptMedia.js
+++ b/modules/RaptMedia/resources/mw.RaptMedia.js
@@ -169,7 +169,7 @@
 			this.setConfig('status', 'loading', true);
 			this.setConfig('projectId', raptProjectId, true);
 
-			this.getPlayer().getInterface().removeClass('rapt-media-running');
+			this.getPlayer().getInterface().removeClass('raptMediaRunning');
 
 			// Attempt to prevent the last segment from incorrectly triggering ended / replay behavior
 			this.getPlayer().onDoneInterfaceFlag = false;
@@ -531,7 +531,7 @@
 							break;
 						case 'project:start':
 							mw.setConfig('EmbedPlayer.KeepPoster', false);
-							_this.getPlayer().getInterface().addClass('rapt-media-running'); // class to control styling during rapt playback
+							_this.getPlayer().getInterface().addClass('raptMediaRunning'); // class to control styling during rapt playback
 							_this.getPlayer().removePoster();
 							break;
 					}


### PR DESCRIPTION
The large play button shows up inappropriately during playback of a Rapt Media project. This PR adds and removes a class after initial play and at project initialization, respectively. The class force hides (display: none;) the large play button.