### PR TITLE
fix(SUP-13905): Add additional z index to smartContainer as dual scre…

### DIFF
--- a/modules/KalturaSupport/resources/mw.KBaseSmartContainer.js
+++ b/modules/KalturaSupport/resources/mw.KBaseSmartContainer.js
@@ -130,7 +130,7 @@
 			this.pluginsScreenOpened = true;
 
 			var $sc = this.embedPlayer.getVideoHolder().find(".smartContainer");
-			$sc.css("z-index", "1");
+			$sc.css("z-index", "3");
 			$sc.children().hide();
 
 			this.embedPlayer.getInterface().addClass( "pluginsScreenOpened" );

--- a/skins/kdark/css/layout.css
+++ b/skins/kdark/css/layout.css
@@ -2019,7 +2019,7 @@ background-image:  linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transpa
     right : 2px;
     width: 50px !important;
     height: 50px !important;
-    z-index: 2;
+    z-index: 4;
 }
 .closePluginsScreen:active{
     outline: 0;


### PR DESCRIPTION
…en blocks the menu and close button

@OrenMe Let me know what you think about this fix, since the smartContainer dose not extend the kBaseScreen I cannot use its functions to remove everything from the player like the other kBaseScreen plugins do, without rewriting the plugin.

We can perhaps use the dual screen fsm to change the state to hide when the smartContainer is opened and back to the previous state when it is closed. 