### PR TITLE
fix(SUP-14668): restore time after ad rule midroll on iOS

### DIFF
--- a/modules/DoubleClick/resources/mw.DoubleClick.js
+++ b/modules/DoubleClick/resources/mw.DoubleClick.js
@@ -1358,7 +1358,7 @@
                 var adData = event.getAdData();
                 if (adData['adError']) {
                     console.log('Non-fatal error occurred: ' + adData['adError'].getMessage());
-                    this.handleNonFatalError(event);
+                    _this.handleNonFatalError(event);
                 }
             });
 

--- a/modules/DoubleClick/resources/mw.DoubleClick.js
+++ b/modules/DoubleClick/resources/mw.DoubleClick.js
@@ -1161,7 +1161,7 @@
                             _this.embedPlayer.onLoadedCallback = function () {
                                 //Restore original onLoadedCallback
                                 _this.embedPlayer.onLoadedCallback = orgOnLoadedCallback;
-                                if ( _this.getConfig( "adTagUrl" ) ) {
+                                if ( _this.getConfig( "adTagUrl" ) || _this.adTagUrl) {
                                     _this.embedPlayer.seek( _this.timeToReturn );
                                     _this.timeToReturn = null;
                                 }


### PR DESCRIPTION
when using programmatic ad rule midrolls via `mediaProxy.entryCuePoints` then we don't populate the plugin config object adTagUrl and the condition to resume to previous time after midroll depends on it.
What we do is set the instance `this.adTagUrl` so add it to the check.