### PR TITLE
fix(FEC-8418): unmute button always shows

### DIFF
--- a/modules/unMuteOverlayButton/resources/unMuteOverlayButton.js
+++ b/modules/unMuteOverlayButton/resources/unMuteOverlayButton.js
@@ -18,13 +18,20 @@
             },
 
             isSafeEnviornment: function () {
+                var _this = this;
+                var browserSupportMutedAutoplay = function() {
+                    return !!(mw.isDesktopSafari11() || mw.isChromeVersionGreaterThan(66));
+                };
+                var isAutoplayConfigured = function() {
+                    return !!(mw.getConfig('autoPlay') || _this.getPlayer().getRawKalturaConfig('playlistAPI', 'autoPlay'));
+                };
                 if (mw.getConfig('thumbEmbedOrigin') || mw.getConfig('autoMute')) {
                     return false;
                 }
                 if (mw.isMobileDevice()) {
                     return !!mw.getConfig('mobileAutoPlay');
                 } else {
-                    return !!(mw.isDesktopSafari11() || mw.isChromeVersionGreaterThan(66)) && (mw.getConfig('autoPlay') || this.getPlayer().getRawKalturaConfig('playlistAPI', 'autoPlay'));
+                    return browserSupportMutedAutoplay() && isAutoplayConfigured();
                 }
             },
 


### PR DESCRIPTION
The condition used to return `undefined` cause `this.getPlayer().getRawKalturaConfig('playlistAPI', 'autoPlay')` returns undefined if not set