### PR TITLE
fix(SUP-14960): Moved the quarterly play events flags to the onChangeMedia function

### DIFF
--- a/modules/KalturaSupport/resources/mw.kAnalony.js
+++ b/modules/KalturaSupport/resources/mw.kAnalony.js
@@ -128,6 +128,10 @@
 				_this.firstPlay = true;
                 _this.entryPlayCounter++;
                 _this.playSentOnStart = false;
+                _this._p25Once = false;
+                _this._p50Once = false;
+                _this._p75Once = false;
+                _this._p100Once = false;
 			});
 
 			this.embedPlayer.bindHelper( 'userInitiatedPlay' , function () {
@@ -326,10 +330,6 @@
 			});
 		},
 		resetPlayerflags:function(){
-			this._p25Once = false;
-			this._p50Once = false;
-			this._p75Once = false;
-			this._p100Once = false;
 			this.hasSeeked = false;
             this.previousCurrentTime = 0;
 			this.savedPosition = null;

--- a/modules/KalturaSupport/resources/mw.kAnalony.js
+++ b/modules/KalturaSupport/resources/mw.kAnalony.js
@@ -632,4 +632,5 @@
             this.startTime = null;
         }
 	}));
+	
 } )( window.mw, window.jQuery );

--- a/modules/KalturaSupport/resources/mw.kAnalony.js
+++ b/modules/KalturaSupport/resources/mw.kAnalony.js
@@ -126,12 +126,12 @@
 				_this.rateHandler.destroy();
 				_this.bufferTime = 0;
 				_this.firstPlay = true;
-                _this.entryPlayCounter++;
-                _this.playSentOnStart = false;
-                _this._p25Once = false;
-                _this._p50Once = false;
-                _this._p75Once = false;
-                _this._p100Once = false;
+				_this.entryPlayCounter++;
+				_this.playSentOnStart = false;
+				_this._p25Once = false;
+				_this._p50Once = false;
+				_this._p75Once = false;
+				_this._p100Once = false;
 			});
 
 			this.embedPlayer.bindHelper( 'userInitiatedPlay' , function () {


### PR DESCRIPTION
@OrenMe Please review this PR.
Per our F2F and verifying the matter with Eran K I have removed the quarterly play events from resetting upon replaying\seeing the entry,
As a result the drop-off calculations of (#playThrough events / 4) / (#plays) should be corrected.