### PR TITLE
fix(SUP-14947): Addressed the issue with content not resuming when an Adtag is empty

### DIFF
--- a/modules/DoubleClick/resources/mw.DoubleClick.js
+++ b/modules/DoubleClick/resources/mw.DoubleClick.js
@@ -1762,7 +1762,7 @@
             var ad = event.getAd();
             var podInfo = ad && ad.getAdPodInfo();
             var totalPodAds = podInfo && podInfo.getTotalAds();
-            if (!ad || totalPodAds === 1) {
+            if ((ad == false) || totalPodAds === 1) {
                 this.restorePlayer(this.contentDoneFlag);
                 this.embedPlayer.play();
             }


### PR DESCRIPTION
@OrenMe please review this PR.

This issue is a result of a use case of a client that has 2 prerolls in which one of them is empty.
The player is recognizing this as nonFatalError, and redirects it to the handleNonFatalError function, which recognizes the ad as "null" and the if (!ad || totalPodAds === 1) as true, which will cause a behavior of the player never returning properly to the content.

In addition, it seems that this issue was a regression of 
https://github.com/kaltura/mwEmbed/pull/3839 