### PR TITLE
FEC 8433 v2 kanalony referrer is double escaped

### DIFF
--- a/modules/KalturaSupport/resources/mw.kAnalony.js
+++ b/modules/KalturaSupport/resources/mw.kAnalony.js
@@ -550,17 +550,16 @@
             var pageReferrer =  statsEvent[ 'referrer' ];
             var queryPos = pageReferrer.indexOf("?");
             if (queryPos > 0) {
-                pageReferrer = pageReferrer.substring(0, queryPos);
+              pageReferrer = pageReferrer.substring(0, queryPos);
             }
 
-            var encodedReferrer = encodeURIComponent(pageReferrer);
-            if (encodedReferrer.length > 500) {
+            if (pageReferrer.length > 500) {
                 var parser = document.createElement('a');
                 parser.href = pageReferrer;
-                encodedReferrer = encodeURIComponent(parser.origin);
+                pageReferrer =  parser.origin;
             }
 
-            statsEvent[ 'referrer' ] = encodedReferrer;
+            statsEvent[ 'referrer' ] = pageReferrer;
 
 			var eventRequest = {'service' : 'analytics', 'action' : 'trackEvent'};
 			$.each(statsEvent , function (event , value) {

--- a/modules/KalturaSupport/resources/mw.kAnalony.js
+++ b/modules/KalturaSupport/resources/mw.kAnalony.js
@@ -553,6 +553,7 @@
               pageReferrer = pageReferrer.substring(0, queryPos);
             }
 
+            pageReferrer = encodeURIComponent(pageReferrer);
             if (pageReferrer.length > 500) {
                 var parser = document.createElement('a');
                 parser.href = pageReferrer;

--- a/modules/KalturaSupport/resources/mw.kAnalony.js
+++ b/modules/KalturaSupport/resources/mw.kAnalony.js
@@ -546,18 +546,19 @@
             //Get optional playlistAPI
 			this.maybeAddPlaylistId(statsEvent);
 
-            //Shorten the refferer param
+            //Shorten the referrer param
             var pageReferrer =  statsEvent[ 'referrer' ];
             var queryPos = pageReferrer.indexOf("?");
             if (queryPos > 0) {
               pageReferrer = pageReferrer.substring(0, queryPos);
             }
 
-            pageReferrer = encodeURIComponent(pageReferrer);
-            if (pageReferrer.length > 500) {
+            var encodedReferrer = encodeURIComponent(pageReferrer);
+            if (encodedReferrer.length > 500) {
                 var parser = document.createElement('a');
                 parser.href = pageReferrer;
                 pageReferrer =  parser.origin;
+
             }
 
             statsEvent[ 'referrer' ] = pageReferrer;


### PR DESCRIPTION
@OrenMe Please review this PR.

I removed the encodeURI functions from the Kanalony code