### PR TITLE
support default language selection natively (by ios browser)

### DIFF
--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
@@ -1578,7 +1578,9 @@
 								'default': textTrack.mode === 'showing',
 								'index': i
 							});
-							textTrack.mode = 'disabled';
+							if (!_this.isNativeIOSPlayback()) {
+								textTrack.mode = 'disabled';
+							}
 						}
 					}
 					if (textTracksData.languages.length) {
@@ -1599,6 +1601,11 @@
 				}
 			}, 1000);
 		},
+
+		isNativeIOSPlayback: function() {
+			return mw.isIOS() && !mw.isIpad() && !mw.getConfig('EmbedPlayer.WebKitPlaysInline');
+		},
+
 		id3Tag: function(metadataTrack){
 			var _this = this;
 			metadataTrack.addEventListener("cuechange", function (evt) {

--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
@@ -1578,9 +1578,7 @@
 								'default': textTrack.mode === 'showing',
 								'index': i
 							});
-							if (!_this.isNativeIOSPlayback()) {
-								textTrack.mode = 'disabled';
-							}
+							textTrack.mode = 'disabled';
 						}
 					}
 					if (textTracksData.languages.length) {
@@ -1601,11 +1599,6 @@
 				}
 			}, 1000);
 		},
-
-		isNativeIOSPlayback: function() {
-			return mw.isIOS() && !mw.isIpad() && !mw.getConfig('EmbedPlayer.WebKitPlaysInline');
-		},
-
 		id3Tag: function(metadataTrack){
 			var _this = this;
 			metadataTrack.addEventListener("cuechange", function (evt) {

--- a/modules/KalturaSupport/resources/mw.ClosedCaptions.js
+++ b/modules/KalturaSupport/resources/mw.ClosedCaptions.js
@@ -119,7 +119,6 @@
 						_this.handleDefaultSource();
 						_this.buildMenu( newSources );
 						outOfBandCaptionEventHandlers.call(_this);
-                        _this.maybeRegisterTextTrackChangeHandler.call(_this);
 					}
 				} );
 			} else {
@@ -274,7 +273,6 @@
 			this.bind( 'onOpenFullScreen', function (){
 				if ( mw.isIOS() && _this.isNativeFullScreenEnabled() && _this.selectedSource ) {
 					_this.embedPlayer.selectDefaultCaption(_this.selectedSource.srclang);
-					_this.maybeRegisterTextTrackChangeHandler();
 				}
 			});
 			this.bind( 'onCloseFullScreen', function (){
@@ -294,28 +292,6 @@
 				}
 			});
 		},
-        /**
-         * support saving user selected text track language in iOS native player
-         */
-        maybeRegisterTextTrackChangeHandler: function () {
-            if (this.getConfig('useCookie') && !this._registeredNativeTrackChangeHandler) {
-                this._registeredNativeTrackChangeHandler = true;
-                var _this = this;
-                this.embedPlayer.getPlayerElement().textTracks.addEventListener("change", function () {
-                    if (_this.getPlayer().layoutBuilder.isInFullScreen() || _this.isNativeIOSPlayback()) {
-                        var activeSubtitle = _this.embedPlayer.getActiveSubtitle();
-                        var activeLanguage = null;
-                        if (activeSubtitle && activeSubtitle.language) {
-                            activeLanguage = activeSubtitle.language.toLowerCase();
-                        } else {
-                            activeLanguage = "None";
-                        }
-                        _this.log("setting new cookie language " + activeLanguage);
-                        _this.getPlayer().setCookie(_this.cookieName, activeLanguage);
-                    }
-                });
-            }
-        },
 		isNativeIOSPlayback: function() {
 			return mw.isIOS() && !mw.isIpad() && !mw.getConfig('EmbedPlayer.WebKitPlaysInline');
 		},
@@ -463,6 +439,12 @@
 				this.autoSelectSource();
 				if( this.selectedSource ){
 					this.setTextSource(this.selectedSource, false);
+				}
+			}
+			if (!this.selectedSource && this.isNativeIOSPlayback()) {
+				var source = this.selectDefaultSource();
+				if (source) {
+					this.selectDefaultIosTrack(source.srclang);
 				}
 			}
 		},


### PR DESCRIPTION
* revert https://github.com/kaltura/mwEmbed/pull/3895 since `closedCaptions.useCookie` should be `false `in ios player
* This change enables us to config `closedCaptions.useCookie: false` and still enjoy the user preferences which saved by the browser. 