### PR TITLE
fix(SUP-14895): Addressed the matter with Change media is not working in Android on HLS.js

### DIFF
--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
@@ -996,6 +996,11 @@
                                     //If play is rejected then return UI state to pause so user can take action
                                     _this.pause();
                                 });
+                             		 // A workaround for the play promise on Android when changing streams.
+                               if ( _this.firstPlay && !!mw.dualScreen && mw.isAndroid()) {
+                                	_this.pause();
+
+                                	}
                             }
 						}
 

--- a/modules/Hlsjs/resources/hlsjs.js
+++ b/modules/Hlsjs/resources/hlsjs.js
@@ -718,7 +718,11 @@
 			playerSwitchSource: function (src, switchCallback, doneCallback) {
 				if (!this.mediaAttached){
 					this.unbind("firstPlay");
-					this.unbind("seeking");
+					if (!!mw.dualScreen && mw.isAndroid()) {
+					  this.bind("seeking");
+					  } else {
+					  this.unbind("seeking");
+					  }
 					this.bind("firstPlay", function() {
 						this.hls.attachMedia(this.getPlayer().getPlayerElement());
 					}.bind(this));


### PR DESCRIPTION
@OrenMe I have addressed the matter with DualScreen plugin (Change Stream) in Android when playing over HLS.js.

1. On HLS.js when the media change invoked the player is unbinding the "Seek" method, therefore, the media can never change mid-play, I was able to assess this when inspecting the console.log info: Can't seek - media Element is not ready.
As a fix, I have created a condition that will keep the "Seek" bind when the DualScreen plugin and isAndriod is set to true, and it seems to resolve the issue.

2. On mw.EmbedPlayerNative.js when it seems that we are encountering some playPromise issues when trying to change the media from before playing the entry, as a workaround I have added the same condition as the former and added an additional pause call which will act as a workaround.