### PR TITLE
fix(SUP-15426): user Agent not recognising Android v9

### DIFF
--- a/modules/MwEmbedSupport/mediawiki/mediawiki.client.js
+++ b/modules/MwEmbedSupport/mediawiki/mediawiki.client.js
@@ -99,7 +99,7 @@
 		return ( userAgent.indexOf('Android') != -1 && userAgent.indexOf('Windows') === -1);
 	};
 	mw.isAndroid4andUp = function () {
-		var androidUAStringRegEx = /Android ((\d+)(?:\.\d+){1,2})/;
+		var androidUAStringRegEx = /Android ((\d+)(?:\.\d+){0,2})/;
 		var res = androidUAStringRegEx.exec(userAgent);
 		if ( res == null ){
 			return false;


### PR DESCRIPTION
Google have apparently broken the user agent scheme in Android 9 user agent.
It used to be X.Y.Z, e.g. 4.2.2, 8.0.0 but in Android 9 it's simply one digit version number now.

Android 9 UA:
![image](https://user-images.githubusercontent.com/5461862/45161036-903ebc80-b1f3-11e8-892d-18fdb172781e.png)

Android 8 UA:
![image](https://user-images.githubusercontent.com/5461862/45161050-99c82480-b1f3-11e8-8304-33ff8e79e182.png)
