### PR TITLE
fix(FEC-8538): Addressed the issue when a entry restarts after a midroll when preroll is not set

### DIFF
--- a/modules/DoubleClick/resources/mw.DoubleClick.js
+++ b/modules/DoubleClick/resources/mw.DoubleClick.js
@@ -108,6 +108,7 @@
             if ( mw.getConfig( 'localizationCode' ) ) {
                 _this.localizationCode = mw.getConfig( 'localizationCode' );
             }
+            _this.saveTimeWhenSwitchMedia = mw.isMobileDevice();
             // copy flashVars to KDP to support Chromeless player plugin
             this.copyFlashvarsToKDP( embedPlayer, pluginName );
             this.embedPlayer = embedPlayer;
@@ -503,7 +504,6 @@
                             _this.playerElementLoaded = true;
                             playerElement.load();
                         }
-                        _this.saveTimeWhenSwitchMedia = mw.isMobileDevice();
                         if ( _this.adManagerLoaded ) {
                             _this.startAdsManager();
                         } else {


### PR DESCRIPTION
@itaykinnrot @OrenMe 
Per Itay's suggestion, I have relocated the saveTimeWhenSwitchMedia from the preroll function to the initiation settings, the issue stems from use cases if a preroll is not set, the saveTimeWhenSwitchMedia will never trigger, therefore, restarts the with entry. 