### PR TITLE
fix(SUP-15645): play event is counted twice in KAVA once a pre-roll is triggered first

### DIFF
--- a/modules/KalturaSupport/resources/mw.kAnalony.js
+++ b/modules/KalturaSupport/resources/mw.kAnalony.js
@@ -60,7 +60,7 @@
         playSentOnStart: false,
 		absolutePosition: null,
 		id3TagEventTime: null,
-
+		onPlayStatus: false,
 		smartSetInterval:function(callback,time,monitorObj) {
 			var _this = this;
 			//create the timer speed, a counter and a starting timestamp
@@ -144,13 +144,14 @@
                 }
 
 				if ( !this.isInSequence() && (_this.firstPlay || _this.embedPlayer.currentState !== "play") ){
-					if ( _this.firstPlay ){
+					if ( _this.firstPlay && !_this.onPlayStatus ) {
+						_this.onPlayStatus = true;
                         _this.playSentOnStart = true;
 						_this.timer.start();
 						_this.sendAnalytics(playerEvent.PLAY, {
                             bufferTimeSum: _this.bufferTimeSum
 						});
-					}else{
+					}else if ( _this.embedPlayer.currentState !== "play" ){
                         _this.timer.resume();
 						_this.sendAnalytics(playerEvent.RESUME, {
                             bufferTimeSum: _this.bufferTimeSum

--- a/modules/KalturaSupport/resources/mw.kAnalony.js
+++ b/modules/KalturaSupport/resources/mw.kAnalony.js
@@ -132,6 +132,7 @@
 				_this._p50Once = false;
 				_this._p75Once = false;
 				_this._p100Once = false;
+				_this.onPlayStatus = false;
 			});
 
 			this.embedPlayer.bindHelper( 'userInitiatedPlay' , function () {


### PR DESCRIPTION
@OrenMe 
This issue was a regression bug of  FEC-8456.
Fix:
1. Added the onPlayStatus and set it to false on the Default config.
2. And added it to the PLAY count logic.
3. Altered the RESUME count logic to trigger when the currentState is not "PLAY" that to avoid any miscounts.