### PR TITLE
Fix(FEC-8545): Fixed the Seek issue in the IOS Inline player + added a userAgent for IOS12

### DIFF
--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
@@ -481,7 +481,7 @@
 			// some initial calls to prime the seek:
 			if ( ( vid.currentTime === 0 && callbackCount === 0 ) && vid.readyState === 0 ) { //load video again if not loaded yet (vid.readyState === 0)
 				// when seeking turn off preload none and issue a load call.
-				if(mw.isIpad()){
+				if(mw.isIpad() || mw.isIOSAbove7() || mw.isIOS12()){
 					$(vid).attr('preload', 'auto')[0].load();
 				} else {
 					$(vid).attr('preload', 'auto');

--- a/modules/MwEmbedSupport/mediawiki/mediawiki.client.js
+++ b/modules/MwEmbedSupport/mediawiki/mediawiki.client.js
@@ -197,6 +197,10 @@
         return ( /OS 11_/.test(userAgent) || /Version\/11/.test(userAgent) ) && mw.isIOS();
     };
 
+    mw.isIOS12 = function () {
+        return ( /OS 12_/.test(userAgent) || /Version\/12/.test(userAgent) ) && mw.isIOS();
+    };
+
 	mw.isIOSBelow9 = function () {
 		// mw.isIOSV() methods check mw.isIOS(), but because of the OR operator it will be checked multiple times. 
 		// Short-circuit to save many calls.


### PR DESCRIPTION
@OrenMe Plese review this PR.

1. I have added the isIOSAbove7 and isIOS12 to the if condition, as it was unable to recognize the readyState element (0 = empty) therefore, was never on "ready".

2. Added a isIOS12 userAgent.