### PR TITLE
FEC-8608 IOS autoplay is not working with playsinline=false configuration 

### DIFF
--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
@@ -331,7 +331,7 @@
 			if ( mw.isMobileDevice() ) {
 				var playsinline = true;
 				if ( mw.isIphone() ) {
-					playsinline = this.inline;
+				    $(this.getPlayerElement()).attr('playsinline', '');
 				}
 				return (this.mobileAutoPlay && playsinline) || this.mobilePlayed;
 			}


### PR DESCRIPTION
@OrenMe 
Please review this PR.

1. **this.inline** returns undefined.
2. without the **$(this.getPlayerElement()).attr('playsinline', '');** the autoPlay won't work and we get a playPromise error.

Tested on:
 iPhone X IOS12
 iPhone X IOS11
iPhone 6 IOS 12
