### PR TITLE
fix (SUP-15880/15796): AutoMute doesn't work with Autoplay in chrome

### DIFF
--- a/modules/KalturaSupport/resources/mw.KWidgetSupport.js
+++ b/modules/KalturaSupport/resources/mw.KWidgetSupport.js
@@ -951,7 +951,7 @@ mw.KWidgetSupport.prototype = {
 		if( autoMute && !mw.isMobileDevice()){
 			setTimeout(function(){
 				embedPlayer.toggleMute( true );
-			},300);
+			},0);
 			// autoMute should only happen once per session:
 			embedPlayer.setKalturaConfig( '', 'autoMute', null );
 		}


### PR DESCRIPTION
@OrenMe 

Per our f2f, I was able to see that the toggleMute was called out too late due to the setTimeout function.

Lowering it the wait time to 0 seems to fix the issue.
