### PR TITLE
fix(SUP-15798): live entries are showing black bars upon exiting full screen

### DIFF
--- a/modules/KalturaSupport/components/live/liveCore.js
+++ b/modules/KalturaSupport/components/live/liveCore.js
@@ -335,7 +335,9 @@
 
 			embedPlayer.triggerHelper('onShowInterfaceComponents', [ showComponentsArr ] );
 			embedPlayer.triggerHelper('onHideInterfaceComponents', [ hideComponentsArr ] );
-			embedPlayer.doUpdateLayout();
+			if (!_this.isDVR()) {
+			  embedPlayer.doUpdateLayout();
+			}
 		},
 
 		isDVR: function(){


### PR DESCRIPTION
@OrenMe 
Please review this PR.

The issue is a regression of SUP-4030:
https://github.com/kaltura/mwEmbed/commit/575ee85d4e03acc003d4920b374265b0bd03f052

I just added a condition that will only trigger when the scrubber is hidden (when DVR is set to false).
