### PR TITLE
feat(FEC-8659): reset session id on every media change

### DIFF
--- a/modules/EmbedPlayer/resources/mw.EmbedPlayer.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayer.js
@@ -1753,6 +1753,7 @@
 				this.postSequenceFlag = false;
 				this.shouldEndClip = true;
 				this.mediaLoadedFlag = false;
+                window.kWidgetSupport.resetGUID();
 			}
 
 			// Add a loader to the embed player:

--- a/modules/KalturaSupport/resources/mw.KWidgetSupport.js
+++ b/modules/KalturaSupport/resources/mw.KWidgetSupport.js
@@ -2093,6 +2093,9 @@ mw.KWidgetSupport.prototype = {
 		}
 		return this.kSessionId;
 	},
+    resetGUID: function() {
+        this.kSessionId = null
+    },
 	getKalturaThumbnailUrl: function( thumb ) {
 		if( ! thumb.url ){
 			return mw.getConfig( 'EmbedPlayer.BlackPixel' );

--- a/modules/KalturaSupport/resources/mw.kAnalony.js
+++ b/modules/KalturaSupport/resources/mw.kAnalony.js
@@ -105,7 +105,6 @@
             this.bufferTime = 0;
             this.bufferTimeSum = 0;
 			this.currentBitRate = -1;
-            this.entryPlayCounter = 1;
             this.addBindings();
 	    },
 
@@ -126,7 +125,6 @@
 				_this.rateHandler.destroy();
 				_this.bufferTime = 0;
 				_this.firstPlay = true;
-				_this.entryPlayCounter++;
 				_this.playSentOnStart = false;
 				_this._p25Once = false;
 				_this._p50Once = false;
@@ -438,7 +436,7 @@
 		},
 
 		getEntrySessionId: function(){
-			return this.embedPlayer.evaluate('{configProxy.sessionId}') + "-" + this.entryPlayCounter;
+			return this.embedPlayer.evaluate('{configProxy.sessionId}')
 		},
 
         getPosition: function () {


### PR DESCRIPTION
use it in kanalony reprots as the unique id and remove the addition of player counter