### PR TITLE
SUP-16282 VTT/DFXP captions are showing when cc is off

### DIFF
--- a/modules/Hlsjs/resources/hlsjs.js
+++ b/modules/Hlsjs/resources/hlsjs.js
@@ -313,7 +313,7 @@
 		            var vid = this.getPlayer().getPlayerElement();
 		            var textTracks = vid.textTracks;
 		            for (var i=0; i < textTracks.length; i++){
-			            textTracks[i].mode = "hidden";
+			            textTracks[i].mode = "disabled";
 		            }
 	            }
             },


### PR DESCRIPTION
Seems to be a regression of FEC-8210.
Change the "hidden" parameter to "disabled".