### PR TITLE
fix: unmute doesn't get destroyed in playlist player

### DIFF
--- a/modules/unMuteOverlayButton/resources/unMuteOverlayButton.js
+++ b/modules/unMuteOverlayButton/resources/unMuteOverlayButton.js
@@ -56,12 +56,6 @@
                 this.getComponent().fadeOut('slow');
             },
 
-            destroy: function () {
-                this.hide();
-                this.unbind('playerReady');
-                this.unbind('volumeChanged');
-            },
-
             getComponent: function () {
                 if (!this.$el) {
                     this.$el = $('<button/>')

--- a/modules/unMuteOverlayButton/resources/unMuteOverlayButton.js
+++ b/modules/unMuteOverlayButton/resources/unMuteOverlayButton.js
@@ -43,17 +43,15 @@
 
                 this.bind('volumeChanged', function () {
                     if ((this.getPlayer().getPlayerElementVolume() > 0) && !this.getPlayer().isMuted()) {
-                        this.hide();
+                        this.getComponent().fadeOut('slow', function () {
+                            this.destroy();
+                        });
                     }
                 }.bind(this));
             },
 
             show: function () {
                 this.getComponent().fadeIn('slow');
-            },
-
-            hide: function () {
-                this.getComponent().fadeOut('slow', function () {this.destroy()});
             },
 
             getComponent: function () {

--- a/modules/unMuteOverlayButton/resources/unMuteOverlayButton.js
+++ b/modules/unMuteOverlayButton/resources/unMuteOverlayButton.js
@@ -43,7 +43,7 @@
 
                 this.bind('volumeChanged', function () {
                     if ((this.getPlayer().getPlayerElementVolume() > 0) && !this.getPlayer().isMuted()) {
-                        this.destroy();
+                        this.hide();
                     }
                 }.bind(this));
             },
@@ -53,7 +53,7 @@
             },
 
             hide: function () {
-                this.getComponent().fadeOut('slow');
+                this.getComponent().fadeOut('slow', function () {this.destroy()});
             },
 
             getComponent: function () {


### PR DESCRIPTION
destroy super does unbind and also remove so no need to implement the method, which causes the bug in playlist player anyway where the indication doesn't go away after user clicks on playlist