### PR TITLE
SUP-16617 - thumbnails are not showing in IOS

### DIFF
--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
@@ -333,11 +333,10 @@
 		canAutoPlay: function () {
 			if ( mw.isMobileDevice() ) {
 				var playsinline = true;
-				if (( mw.isIphone() && mw.getConfig("EmbedPlayer.WebKitPlaysInline") !== true )) {
+				if ( mw.isIphone()) {
 					playsinline = this.inline;
-					return (this.mobileAutoPlay && playsinline) || this.mobilePlayed;
 				}
-				return (this.mobileAutoPlay && playsinline) || this.mobilePlayed || this.isMuted();
+				return (this.mobileAutoPlay || this.isMuted()) && playsinline || this.mobilePlayed;
 			}
 			return true;
 			},

--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
@@ -336,7 +336,7 @@
 				if ( mw.isIphone()) {
 					playsinline = this.inline;
 				}
-				return (this.mobileAutoPlay || this.isMuted()) && playsinline || this.mobilePlayed;
+				return ((this.mobileAutoPlay || this.isMuted()) && playsinline) || this.mobilePlayed;
 			}
 			return true;
 			},

--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
@@ -333,8 +333,9 @@
 		canAutoPlay: function () {
 			if ( mw.isMobileDevice() ) {
 				var playsinline = true;
-				if ( mw.isIphone() ) {
+				if (( mw.isIphone() && mw.getConfig("EmbedPlayer.WebKitPlaysInline") !== true )) {
 					playsinline = this.inline;
+					return (this.mobileAutoPlay && playsinline) || this.mobilePlayed;
 				}
 				return (this.mobileAutoPlay && playsinline) || this.mobilePlayed || this.isMuted();
 			}


### PR DESCRIPTION
The canAutoPlay function is still trying to autoPlay in the Native IOS Player however fails due to the player not being inline, that is why the thumbnails are not showing when the autoPlay and mobileAutoPlay are set to true.

The fix is to add the original return autoplay without the isMuted() function to the if isiPhone validation and I have also added && mw.getConfig("EmbedPlayer.WebKitPlaysInline") !== true ) for safety mesurs.