### PR TITLE
fix(SUP-16764): Quiz.plugin pushes the captions upwards.

### DIFF
--- a/modules/Quiz/resources/css/quiz.css
+++ b/modules/Quiz/resources/css/quiz.css
@@ -806,7 +806,7 @@ ol.second-row{
 }
 
 .track {
-    bottom:9vh!important;
+    bottom:9vh;
 }
 
 .cp-navigation{


### PR DESCRIPTION
@eitanavgil 
Seems that the quiz CSS was pushing the captions upwards by 9vh for some reason.
I have just deleted the _!important_ since it was bothering the user in the use case when the quiz plugin is activated however the entry is not a quiz type.