### PR TITLE
fix(FEC-8501): iOS Scrubber is disabled after selecting 'learn more' on ad

### DIFF
--- a/modules/DoubleClick/resources/mw.DoubleClick.js
+++ b/modules/DoubleClick/resources/mw.DoubleClick.js
@@ -656,7 +656,7 @@
             if ( this.isChromeless ) {
                 $( ".videoDisplay" ).prepend( adCover );
             } else {
-                if ( !mw.isIphone() && !_this.isVPAID) {
+                if ( !mw.isNativeIOSPlayback() && !_this.isVPAID ) {
                     $( this.getAdContainer() ).append( adCover );
                 }
             }


### PR DESCRIPTION
The issue was with the `getAdContainer` not appending to the adCover when iOS is set to WebKitPlaysInline=true