### PR TITLE
feat(FEC-8884): Support muted autoplay policies on Firefox

### DIFF
--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
@@ -150,7 +150,7 @@
             if (!mw.getConfig('autoMute')) {
                 if (mw.isMobileDevice() || mw.isIpad()) {
                     return mw.getConfig('mobileAutoPlay');
-                } else if ((mw.isDesktopSafariVersionGreaterThan(11) || mw.isChromeVersionGreaterThan(66)) && mw.getConfig('autoPlay')) {
+                } else if ((mw.isDesktopSafariVersionGreaterThan(11) || mw.isChromeVersionGreaterThan(66) || mw.isFirefoxVersionGreaterThan(66)) && mw.getConfig('autoPlay')) {
                     if (typeof mw.getConfig('autoPlayFallbackToMute') !== 'boolean') {
                         mw.setConfig('autoPlayFallbackToMute', true);
                     }

--- a/modules/MwEmbedSupport/mediawiki/mediawiki.client.js
+++ b/modules/MwEmbedSupport/mediawiki/mediawiki.client.js
@@ -124,6 +124,13 @@
 	mw.isFirefox = function () {
 		return ( userAgent.indexOf('Firefox') != -1 );
 	};
+
+	mw.isFirefoxVersionGreaterThan = function (version) {
+		var fireFoxVersion = mw.getFireFoxVersion();
+		var fireFoxMajorVersion = fireFoxVersion[0];
+		return ( mw.isFirefox() && fireFoxMajorVersion >= version );
+	};
+
 	mw.isChrome = function () {
 		return ( userAgent.indexOf('Chrome') != -1 && !mw.isEdge() );
 	};
@@ -422,6 +429,15 @@
             chromeVersionParts = chromeVersion[1].split(".");
 		}
 		return chromeVersionParts;
+	};
+
+	mw.getFireFoxVersion = function(){
+		var fireFoxVersionParts = [0, 0, 0, 0];
+		var fireFoxVersion = userAgent.match(/.*Firefox\/([0-9\.]+)/);
+		if (fireFoxVersion && fireFoxVersion[1]){
+			fireFoxVersionParts = fireFoxVersion[1].split(".");
+		}
+		return fireFoxVersionParts;
 	};
 
 })(window.mediaWiki);

--- a/modules/unMuteOverlayButton/resources/unMuteOverlayButton.js
+++ b/modules/unMuteOverlayButton/resources/unMuteOverlayButton.js
@@ -20,7 +20,7 @@
             isSafeEnviornment: function () {
                 var _this = this;
                 var browserSupportMutedAutoplay = function() {
-                    return !!(mw.isDesktopSafariVersionGreaterThan(11) || mw.isChromeVersionGreaterThan(66));
+                    return !!(mw.isDesktopSafariVersionGreaterThan(11) || mw.isChromeVersionGreaterThan(66) || mw.isFirefoxVersionGreaterThan(66));
                 };
                 var isAutoplayConfigured = function() {
                     return !!(mw.getConfig('autoPlay') || _this.getPlayer().getRawKalturaConfig('playlistAPI', 'autoPlay'));


### PR DESCRIPTION
Added Support to the new autoPlay policy in Firefox 66.
https://hacks.mozilla.org/2019/02/firefox-66-to-block-automatically-playing-audible-video-and-audio/
