### PR TITLE
fix(FEC-7899): spinning wheel when returning to live

### DIFF
--- a/modules/Hlsjs/resources/hlsjs.js
+++ b/modules/Hlsjs/resources/hlsjs.js
@@ -68,6 +68,7 @@
 				this.bind("playerReady", this.initHls.bind(this));
 				this.bind("onChangeMedia", this.clean.bind(this));
 				this.bind("liveOnline", this.onLiveOnline.bind(this));
+				this.bind("liveOffline", this.stopLoad.bind(this));
 				if (mw.getConfig("hlsLogs")) {
 					this.bind("monitorEvent", this.monitorDebugInfo.bind(this));
 				}
@@ -717,6 +718,12 @@
 				}
 			},
 			/**
+			* Override player method for stop the video element
+			*/
+			stopLoad: function () {
+				this.hls.stopLoad();
+			},
+			/**
 			 * Override player callback after changing media
 			 */
 			playerSwitchSource: function (src, switchCallback, doneCallback) {
@@ -793,7 +800,9 @@
 					this.registerHlsEvents();
 					this.mediaAttached = false;
 					this.hls.attachMedia(this.embedPlayer.getPlayerElement());
-				}
+					} else {
+							this.hls.startLoad(this.hls.config.startPosition);
+					}
 			},
 
 			getStartTimeOfDvrWindow: function () {


### PR DESCRIPTION
Fixed the issue when the live streams are erroring in non-DVR live events and as a result, are not recovering. 

1. Added the `this.hls.stopLoad();` when `liveOffline` is called.  
2. Added an additional condition to 'onLiveOnline' function when is non-DVR that will startLoad on the default `startPosition` which is -1 when returning to live.

Tested this on my local environment. 