### PR TITLE
fix(FEC-8989): YouTube entires are stuck on endless spinner when on autoPlay

### DIFF
--- a/modules/ExternalPlayers/resources/mw.EmbedPlayerYouTube.js
+++ b/modules/ExternalPlayers/resources/mw.EmbedPlayerYouTube.js
@@ -102,6 +102,7 @@
             //autoplay
             if(mw.getConfig('autoPlay') && this.canAutoPlay()){
                 this.unbindHelper("preSeek");
+                this.setVolume(0);
                 this.play();
             }
 


### PR DESCRIPTION
Added set Volume to 0 to comply with the AutoMute policies with YouTube entries.  