### PR TITLE
fix(SUP 17081): undefined sources are added to sourceSelector menu as empty spaces

### DIFF
--- a/modules/KalturaSupport/components/sourceSelector.js
+++ b/modules/KalturaSupport/components/sourceSelector.js
@@ -142,9 +142,8 @@
                 this.getPlayer().mediaElement.removeSourceFlavor(sources);
             }
 
-			if( sources.length == 1 ){
-				// no need to do building menu logic. 
-				this.addSourceToMenu( sources[0], _this.getSourceTitle(sources[0]) );
+			if( sources.length == 1 && this.getPlayer().streamerType != "http" ){
+				// no need to do building menu logic.
 				return ;
 			}
 			// sort by height then bitrate:

--- a/modules/KalturaSupport/components/sourceSelector.js
+++ b/modules/KalturaSupport/components/sourceSelector.js
@@ -312,7 +312,7 @@
 			var _this = this;
 
             var sourceLabel = this.getSourceTitle( source );
-            if( $.inArray(sourceLabel, this.sourcesList) == -1 ) {
+            if( $.inArray(sourceLabel, this.sourcesList) == -1 && source.src !== undefined ) {
 
                 this.sourcesList.push(sourceLabel);
 

--- a/modules/KalturaSupport/components/sourceSelector.js
+++ b/modules/KalturaSupport/components/sourceSelector.js
@@ -312,7 +312,7 @@
 			var _this = this;
 
             var sourceLabel = this.getSourceTitle( source );
-            if( $.inArray(sourceLabel, this.sourcesList) == -1 && source.src !== undefined ) {
+            if( $.inArray(sourceLabel, this.sourcesList) == -1 ) {
 
                 this.sourcesList.push(sourceLabel);
 

--- a/modules/KalturaSupport/resources/mw.ClosedCaptions.js
+++ b/modules/KalturaSupport/resources/mw.ClosedCaptions.js
@@ -1151,10 +1151,8 @@
             // Add text sources
             for (var j = 0; j < sources.length; j++) {
                 var src = sources[j];
-                if (src.label !== "") {
-                  this.addSourceButton(src);
-                  items.push({'label': src.label, 'value': src.label});
-                }
+                this.addSourceButton(src);
+                items.push({'label': src.label, 'value': src.label});
             }
 
 			this.getActiveCaption();

--- a/modules/KalturaSupport/resources/mw.ClosedCaptions.js
+++ b/modules/KalturaSupport/resources/mw.ClosedCaptions.js
@@ -1151,8 +1151,10 @@
             // Add text sources
             for (var j = 0; j < sources.length; j++) {
                 var src = sources[j];
-                this.addSourceButton(src);
-                items.push({'label': src.label, 'value': src.label});
+                if (src.label !== "") {
+                  this.addSourceButton(src);
+                  items.push({'label': src.label, 'value': src.label});
+                }
             }
 
 			this.getActiveCaption();


### PR DESCRIPTION
In some use cases, streamSelectors and ClosedCaption are rendering empty sources (undefined) as small empty spaces on the drop-down menu. 
