### PR TITLE
fix(FEC-9085): playState is marked as "paused" although playing

### DIFF
--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
@@ -1309,9 +1309,15 @@
 			}
 
 			// Update the interface ( if paused )
-			if (!this.ignoreNextNativeEvent && this._propagateEvents && this.paused || (mw.isIpad() && ( mw.getConfig('EmbedPlayer.EnableIpadHTMLControls') === true ))) {
-				this.parent_play();
-			} else {
+			if (mw.isIpad() && ( mw.getConfig('EmbedPlayer.EnableIpadHTMLControls') === true )) {
+				if (!this.ignoreNextNativeEvent && this._propagateEvents && this.paused ) {
+					this.parent_play();
+				}
+			}
+			if (!this.ignoreNextNativeEvent && this._propagateEvents && this.paused) {
+					this.parent_play();
+			}
+			else {
 				// make sure the interface reflects the current play state if not calling parent_play()
 				this.playInterfaceUpdate();
 				this.absoluteStartPlayTime = new Date().getTime();

--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
@@ -1309,12 +1309,10 @@
 			}
 
 			// Update the interface ( if paused )
-			if (mw.isIpad() && ( mw.getConfig('EmbedPlayer.EnableIpadHTMLControls') === true )) {
-				if (!this.ignoreNextNativeEvent && this._propagateEvents && this.paused ) {
-					this.parent_play();
-				}
-			}
-			if (!this.ignoreNextNativeEvent && this._propagateEvents && this.paused) {
+			var enableIpadHTMLControls = mw.isIpad() ?
+				( mw.getConfig('EmbedPlayer.EnableIpadHTMLControls') === true ) : true;
+
+			if (!this.ignoreNextNativeEvent && this._propagateEvents && this.paused && enableIpadHTMLControls) {
 					this.parent_play();
 			}
 			else {

--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
@@ -1309,7 +1309,7 @@
 			}
 
 			// Update the interface ( if paused )
-			if (!this.ignoreNextNativeEvent && this._propagateEvents && this.paused && ( mw.getConfig('EmbedPlayer.EnableIpadHTMLControls') === true )) {
+			if (!this.ignoreNextNativeEvent && this._propagateEvents && this.paused || (mw.isIpad() && ( mw.getConfig('EmbedPlayer.EnableIpadHTMLControls') === true ))) {
 				this.parent_play();
 			} else {
 				// make sure the interface reflects the current play state if not calling parent_play()


### PR DESCRIPTION
Added isIPad checker to the interface update, in case `EmbedPlayer.EnableIpadHTMLControls` config is set to false.