### PR TITLE
fix(SUP-18895): Vertical Space is cutting Thai letters

### DIFF
--- a/modules/KalturaSupport/resources/mw.ClosedCaptions.js
+++ b/modules/KalturaSupport/resources/mw.ClosedCaptions.js
@@ -1015,7 +1015,6 @@
 		getDefaultCaptionCss: function(){
 			var style = {};
 			style["display"] = "inline-block";
-			style["line-height"] = "2";
 			if (this.getConfig('bg')) {
 				style["background-color"] = mw.getHexColor(this.getConfig('bg'));
 			}

--- a/modules/KalturaSupport/resources/mw.ClosedCaptions.js
+++ b/modules/KalturaSupport/resources/mw.ClosedCaptions.js
@@ -1014,7 +1014,8 @@
 		},
 		getDefaultCaptionCss: function(){
 			var style = {};
-			style["display"] = "inline";
+			style["display"] = "inline-block";
+			style["line-height"] = "2";
 			if (this.getConfig('bg')) {
 				style["background-color"] = mw.getHexColor(this.getConfig('bg'));
 			}


### PR DESCRIPTION
Added additional line spacing for the default Closed Captioning style in order to support Thai Characters.