### PR TITLE
FEV-320 - start playing on a question-cue-point click

### DIFF
--- a/modules/Quiz/resources/quiz.js
+++ b/modules/Quiz/resources/quiz.js
@@ -1149,6 +1149,9 @@
         onBubbleClick: function (event) {
             var qNumber = parseInt($(event.target).attr("id"));
             this.seekToQuestionTime = $.cpObject.cpArray[qNumber].startTime;
+            if (!this.embedPlayer.isPlaying()) { // make sure that when we seek on a question-cue-point it always keeps playing and not paused
+                this.embedPlayer.sendNotification("doPlay");
+            }
             this.KIVQModule.gotoScrubberPos(qNumber);
             this.isSeekingIVQ = true;
             mw.log("Quiz: gotoScrubberPos : " + qNumber);


### PR DESCRIPTION
on CP click it seeked 0.5 sec before the question cue-point marker, so in case when video is paused - it seeked 0.5 sec before the CP and stayed paused.
The changes makes sure that when we seek on a question-cue-point it always keeps playing and not paused.