### PR TITLE
FEV-318 - hide 'Why' bubble when feedback popup is visible

### DIFF
--- a/modules/Quiz/resources/quiz.js
+++ b/modules/Quiz/resources/quiz.js
@@ -808,7 +808,8 @@
                         .off()
                         .on('keydown', _this.keyDownHandler)
                         .on('click',function(e){
-                            $(".feedback-modal").show()
+                            $(".header-container").hide();
+                            $(".feedback-modal").show();
                             $(".reviewAnswerPlace").hide();
                             $(".reviewAnswerFooter").hide();
                             $(".feedback-modal .icon-close").focus();
@@ -819,6 +820,7 @@
                         .on('keydown', _this.keyDownHandler)
                         .on('click',function(e){
                             $(".feedback-modal").hide();
+                            $(".header-container").show();
                             $(".reviewAnswerPlace").show();
                             $(".reviewAnswerFooter").show();
                         })
@@ -1087,7 +1089,6 @@
                     $(_this).parents(".quiz").find(".feedback").focus();
                 }
             }else if(ev.which === 9){
-                console.log(">>>>",target);
                 setTimeout(function () {
                     var currentFocusedElement = $(':focus');//when timeout will done - new element will be in focus
                     if(!currentFocusedElement.parents('.quiz').length){
@@ -1101,7 +1102,6 @@
                             $(_this).parents(".quiz").find(".hint-why-box").focus();
                         }else if($(target).hasClass("feedback-content")){
                             // open feedback popup - focus on close button
-                            console.log(">>>> !!");
                             $(_this).parents(".quiz").find(".icon-close").focus();
                         }else{
                             // if hint isn't there - focus on the name


### PR DESCRIPTION
Problem description: 
'Why' bubble appears on feedback page cousin to overlap exit button 

changes:
Hide 'Why' bubble when feedback popup is visible
