### PR TITLE
fix(SUP-18987): issue with aspect in 360

### DIFF
--- a/modules/KalturaSupport/components/360/resources/video360.js
+++ b/modules/KalturaSupport/components/360/resources/video360.js
@@ -15,7 +15,7 @@
             mobileVibrationValue: (mw.isAndroidNativeBrowser() ? 1 : 0.02),
 			cameraOptions: {
 				fov: 75,
-				aspect: window.innerWidth / window.innerHeight > 1 ? window.innerWidth / window.innerHeight : 1.4,
+				aspect: window.innerWidth / window.innerHeight > 1 ? window.innerWidth / window.innerHeight : 1,
 				near: 0.1,
 				far: 1000
 			}

--- a/modules/KalturaSupport/components/360/resources/video360.js
+++ b/modules/KalturaSupport/components/360/resources/video360.js
@@ -15,7 +15,7 @@
             mobileVibrationValue: (mw.isAndroidNativeBrowser() ? 1 : 0.02),
 			cameraOptions: {
 				fov: 75,
-				aspect: window.innerWidth / window.innerHeight,
+				aspect: window.innerWidth / window.innerHeight > 1 ? window.innerWidth / window.innerHeight : 1.4,
 				near: 0.1,
 				far: 1000
 			}

--- a/modules/KalturaSupport/components/360/resources/video360.js
+++ b/modules/KalturaSupport/components/360/resources/video360.js
@@ -13,9 +13,10 @@
 			// 360 default config
 			moveMultiplier: 0.5,
             mobileVibrationValue: (mw.isAndroidNativeBrowser() ? 1 : 0.02),
+			defaultAspect: (640/360),
 			cameraOptions: {
 				fov: 75,
-				aspect: window.innerWidth / window.innerHeight > 1.4 ? window.innerWidth / window.innerHeight : 1.4,
+				aspect: window.innerWidth / window.innerHeight,
 				near: 0.1,
 				far: 1000
 			}
@@ -88,6 +89,9 @@
 			//Get user camera configuration
 			var userCameraOptions = this.getConfig("cameraOptions");
 			//Deep extend custom config
+			if (this.defaultConfig.cameraOptions.aspect < this.defaultConfig.defaultAspect) {
+				this.defaultConfig.cameraOptions.aspect = this.defaultConfig.defaultAspect;
+			}
 			this.cameraOptions = $.extend({}, this.defaultConfig.cameraOptions, userCameraOptions);
 
 			//Get user vr mode configuration

--- a/modules/KalturaSupport/components/360/resources/video360.js
+++ b/modules/KalturaSupport/components/360/resources/video360.js
@@ -15,7 +15,7 @@
             mobileVibrationValue: (mw.isAndroidNativeBrowser() ? 1 : 0.02),
 			cameraOptions: {
 				fov: 75,
-				aspect: window.innerWidth / window.innerHeight > 1 ? window.innerWidth / window.innerHeight : 1,
+				aspect: window.innerWidth / window.innerHeight > 1.4 ? window.innerWidth / window.innerHeight : 1.4,
 				near: 0.1,
 				far: 1000
 			}

--- a/modules/KalturaSupport/components/360/resources/video360.js
+++ b/modules/KalturaSupport/components/360/resources/video360.js
@@ -1,7 +1,7 @@
 (function (mw, $, THREE) {
 	"use strict";
 
-	var DEFAULT_ASPECT = Math.max(640/360);
+	var DEFAULT_ASPECT = 640/360;
 
 	mw.PluginManager.add('video360', mw.KBaseComponent.extend({
 		defaultConfig: {

--- a/modules/KalturaSupport/components/360/resources/video360.js
+++ b/modules/KalturaSupport/components/360/resources/video360.js
@@ -1,8 +1,9 @@
 (function (mw, $, THREE) {
 	"use strict";
 
-	mw.PluginManager.add('video360', mw.KBaseComponent.extend({
+	var DEFAULT_ASPECT = Math.max(640/360);
 
+	mw.PluginManager.add('video360', mw.KBaseComponent.extend({
 		defaultConfig: {
 			// vr button default config
 			align: "right",
@@ -13,10 +14,9 @@
 			// 360 default config
 			moveMultiplier: 0.5,
             mobileVibrationValue: (mw.isAndroidNativeBrowser() ? 1 : 0.02),
-			defaultAspect: (640/360),
 			cameraOptions: {
 				fov: 75,
-				aspect: window.innerWidth / window.innerHeight,
+				aspect: Math.max(window.innerWidth / window.innerHeight, DEFAULT_ASPECT),
 				near: 0.1,
 				far: 1000
 			}
@@ -89,9 +89,6 @@
 			//Get user camera configuration
 			var userCameraOptions = this.getConfig("cameraOptions");
 			//Deep extend custom config
-			if (this.defaultConfig.cameraOptions.aspect < this.defaultConfig.defaultAspect) {
-				this.defaultConfig.cameraOptions.aspect = this.defaultConfig.defaultAspect;
-			}
 			this.cameraOptions = $.extend({}, this.defaultConfig.cameraOptions, userCameraOptions);
 
 			//Get user vr mode configuration


### PR DESCRIPTION
Issue with aspect calculation when 360 video is on a playlist, the aspect is miscalculated (includes the hight or width of the playlist) and results in a malformed video display.

The calculation was if the original calculation was less than 1.4, we will set it to 1.4