### PR TITLE
fix(SUP-18602): Bumper does not work when the webcastPolls plugin is added

### DIFF
--- a/modules/WebcastPolls/resources/webcastPolls.js
+++ b/modules/WebcastPolls/resources/webcastPolls.js
@@ -81,6 +81,9 @@
 
             }else
             {
+                _this.unbind('onpause onplay onChangeMedia movingBackToLive', function (e) {
+                    _this.handlePlayerEvent(e.type);
+                });
                 _this.log("entry is in vod mode - disable voting feature for polls");
 
             }


### PR DESCRIPTION
The issue is when a player is implemented in the KMS and the Polls feature is set.
In the KMS the polls is getting added to the player bu default and is causing some issues, and the most permanent one is overriding the bumper plugin.

In my fix I just added an unbind to the player events when the poll is getting disabled.
