### PR TITLE
fix(SUP-18477): save input if user is clicking of the why button a second time

### DIFF
--- a/modules/Quiz/resources/quiz.js
+++ b/modules/Quiz/resources/quiz.js
@@ -508,6 +508,7 @@
         buildOpenQuestion: function(cPo){
             var _this = this;
             var interfaceElement = this.embedPlayer.getInterface();
+            interfaceElement.find(".open-question-textarea")[0].focus();
             // clear button
             interfaceElement.find("#open-question-clear")
             .off()
@@ -550,7 +551,7 @@
                     interfaceElement.find("#open-question-clear,#open-question-save").removeAttr("disabled");
                 }
             })
-            .change(function(){
+            .bind('change focusout', function(){
                 var holdAnswer = $(this).val();
                 interfaceElement.find(".hint-why-box")
                 .click(function () {


### PR DESCRIPTION
@einatr 
I've changed the `focus` from the question to the open-area element and that will save the question even if the user clicked the question a second time without changing the answer. 