### PR TITLE
fix(19550): Duration tag on YT playlists does not update

### DIFF
--- a/modules/ExternalPlayers/resources/mw.EmbedPlayerYouTube.js
+++ b/modules/ExternalPlayers/resources/mw.EmbedPlayerYouTube.js
@@ -372,6 +372,7 @@
 		},
 		changeMediaCallback: function (callback) {
 			var _this = this;
+			_this.hasEnded = false;
 			if (mw.isMobileDevice()){
 				$(".mwEmbedPlayer").width(0);
 			}


### PR DESCRIPTION
@OrenMe 
We don't reset the hasEnded flag when calling change media, therefore, we do not call setDuration:
https://github.com/kaltura/mwEmbed/blob/master/modules/ExternalPlayers/resources/mw.EmbedPlayerYouTube.js#L175-L177