### PR TITLE
fix(SUP-18965): Incorrect DualScreen layout with ThumbEmbed

### DIFF
--- a/kWidget/kWidget.js
+++ b/kWidget/kWidget.js
@@ -1160,7 +1160,7 @@
 			}
 
 			// Check if we need to capture a play event ( iOS sync embed call )
-			if (settings.captureClickEventForiOS && (this.isSafari() && !this.isChrome() || this.isAndroid())) {
+			if (settings.captureClickEventForiOS && ((this.isSafari() && !this.isChrome()) || this.isAndroid())) {
 				this.captureClickWrapedIframeUpdate(targetId, requestSettings, iframe);
 			} else {
 				// get the callback name:

--- a/kWidget/kWidget.js
+++ b/kWidget/kWidget.js
@@ -1160,7 +1160,7 @@
 			}
 
 			// Check if we need to capture a play event ( iOS sync embed call )
-			if (settings.captureClickEventForiOS && (this.isSafari() || this.isAndroid())) {
+			if (settings.captureClickEventForiOS && (this.isSafari() && !this.isChrome() || this.isAndroid())) {
 				this.captureClickWrapedIframeUpdate(targetId, requestSettings, iframe);
 			} else {
 				// get the callback name:
@@ -1290,6 +1290,7 @@
 				'<body>' +
 				'<div class="mwPlayerContainer"  style="width: 100%; height: 100%">' +
 				'<div class="videoHolder">' +
+				'<div class="videoDisplay">' +
 				'<video class="persistentNativePlayer" ' +
 				'id="' + targetId + '" ' +
 				'kwidgetid="' + settings.wid + '" ' +
@@ -1302,6 +1303,7 @@
 				'style="width:100%;height:100%" ' +
 				'>' +
 				'</video>' +
+				'</div>' +
 				'</div>' +
 				'</div>' +
 				// issue play on the silent black video ( to capture iOS gesture )
@@ -1851,6 +1853,9 @@
 		isSafari: function () {
             return (/safari/).test(navigator.userAgent.toLowerCase());
         },
+		isChrome: function () {
+			return (/chrome/).test(navigator.userAgent.toLowerCase());
+		},
 		isWindowsDevice: function () {
 			var appVer = navigator.appVersion;
 			return  ((appVer.indexOf("Win") != -1 &&

--- a/kWidget/kWidget.js
+++ b/kWidget/kWidget.js
@@ -1290,7 +1290,6 @@
 				'<body>' +
 				'<div class="mwPlayerContainer"  style="width: 100%; height: 100%">' +
 				'<div class="videoHolder">' +
-				'<div class="videoDisplay">' +
 				'<video class="persistentNativePlayer" ' +
 				'id="' + targetId + '" ' +
 				'kwidgetid="' + settings.wid + '" ' +
@@ -1303,7 +1302,6 @@
 				'style="width:100%;height:100%" ' +
 				'>' +
 				'</video>' +
-				'</div>' +
 				'</div>' +
 				'</div>' +
 				// issue play on the silent black video ( to capture iOS gesture )


### PR DESCRIPTION
@eitanavgil @OrenMe @yairans 
2 major changes

1. The user agent identifier (added a chrome one and added to the condition) which resolves the issue in Chrome.

It seems that when in Chrome we enter this condition due to the fact that "Safari" string is indeed included in the userAgent, see in the below.


> "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36"


Please note, that adding too many userAgent detectors will cause a StackOverflow.

2. For Safari, added the videoDisplay class to the write function which is in charge of the dual-screen display.