### PR TITLE
fix(SUP-19662): "Off air" string is showing on non-Live entries

### DIFF
--- a/modules/KalturaSupport/components/live/liveStatus.js
+++ b/modules/KalturaSupport/components/live/liveStatus.js
@@ -37,8 +37,10 @@
 			this.bind( 'onChangeMedia', function() {
                 _this.removeBindings();
 				//Reset UI state on change media and liveStatus button
-				_this.setLiveStatusButtonDefaultState();
-				_this.getBtn().show();
+				if( _this.getPlayer().isLive() ) {
+					_this.setLiveStatusButtonDefaultState();
+					_this.getBtn().show();
+				}
             });
 		},
         initStrings: function(){

--- a/modules/KalturaSupport/components/live/liveStatus.js
+++ b/modules/KalturaSupport/components/live/liveStatus.js
@@ -36,12 +36,14 @@
             });
 			this.bind( 'onChangeMedia', function() {
                 _this.removeBindings();
-				//Reset UI state on change media and liveStatus button
+				_this.setLiveStatusButtonDefaultState();
+			});
+			this.bind( 'onChangeMediaDone', function() {
 				if( _this.getPlayer().isLive() ) {
-					_this.setLiveStatusButtonDefaultState();
+					//Reset UI state on change media and liveStatus button
 					_this.getBtn().show();
 				}
-            });
+			});
 		},
         initStrings: function(){
             this.liveText = gM( 'mwe-embedplayer-player-on-air' );


### PR DESCRIPTION
@OrenMe 
It seems that the setLiveStatusButtonDefaultState() is bindded when onChange is getting sent 
(For example: https://github.com/kaltura/mwEmbed/blob/e667d18f51107074fbcdef0c6e5b5e7b543d242a/modules/KalturaSupport/components/related/related.js#L420)

I've added a condition to only apply to LiveStream type entries.