### PR TITLE
fix(FEC-9386): Unmuted button is not working on iPad iOS13

### DIFF
--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
@@ -148,7 +148,7 @@
 				return false;
 			}
             if (!mw.getConfig('autoMute')) {
-                if (mw.isMobileDevice() || mw.isIpad() || mw.isIpadOnIos13()) {
+                if (mw.isMobileDevice() || mw.isIpad() || mw.isIpadOS()) {
                     return mw.getConfig('mobileAutoPlay');
                 } else if ((mw.isDesktopSafariVersionGreaterThan(11) || mw.isChromeVersionGreaterThan(66) || mw.isFirefoxVersionGreaterThan(66)) && mw.getConfig('autoPlay')) {
                     if (typeof mw.getConfig('autoPlayFallbackToMute') !== 'boolean') {
@@ -167,7 +167,7 @@
                 unMuteEventTriggers.forEach(function (eventName) {
                     _this.bindHelper(eventName + _this.bindPostfix, function () {
                         if (_this.mobileAutoPlay) {
-                            _this.setVolume(1, null, (mw.isIOS() || mw.isIpadOnIos13()));
+                            _this.setVolume(1, null, (mw.isIOS() || mw.isIpadOS()));
                             _this.mobileAutoPlay = false;
                         }
                         unMuteEventTriggers.forEach(function (eventName) {

--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
@@ -148,7 +148,7 @@
 				return false;
 			}
             if (!mw.getConfig('autoMute')) {
-                if (mw.isMobileDevice() || mw.isIpad()) {
+                if (mw.isMobileDevice() || mw.isIpad() || mw.isIpadOnIos13()) {
                     return mw.getConfig('mobileAutoPlay');
                 } else if ((mw.isDesktopSafariVersionGreaterThan(11) || mw.isChromeVersionGreaterThan(66) || mw.isFirefoxVersionGreaterThan(66)) && mw.getConfig('autoPlay')) {
                     if (typeof mw.getConfig('autoPlayFallbackToMute') !== 'boolean') {
@@ -167,7 +167,7 @@
                 unMuteEventTriggers.forEach(function (eventName) {
                     _this.bindHelper(eventName + _this.bindPostfix, function () {
                         if (_this.mobileAutoPlay) {
-                            _this.setVolume(1, null, mw.isIOS());
+                            _this.setVolume(1, null, (mw.isIOS() || mw.isIpadOnIos13()));
                             _this.mobileAutoPlay = false;
                         }
                         unMuteEventTriggers.forEach(function (eventName) {

--- a/modules/MwEmbedSupport/mediawiki/mediawiki.client.js
+++ b/modules/MwEmbedSupport/mediawiki/mediawiki.client.js
@@ -8,7 +8,7 @@
 	var userAgent = navigator.userAgent;
 
 	mw.isMobileDevice = function () {
-		return ( mw.isIphone() || mw.isIpod() || mw.isIpad() || mw.isIpadOnIos13() || mw.isAndroid() || mw.isWindowsPhone() || mw.getConfig("EmbedPlayer.ForceNativeComponent") === true || mw.getConfig("EmbedPlayer.SimulateMobile") === true )
+		return ( mw.isIphone() || mw.isIpod() || mw.isIpad() || mw.isIpadOS() || mw.isAndroid() || mw.isWindowsPhone() || mw.getConfig("EmbedPlayer.ForceNativeComponent") === true || mw.getConfig("EmbedPlayer.SimulateMobile") === true )
 	};
 	mw.isNativeApp = function () {
 		return mw.getConfig("EmbedPlayer.ForceNativeComponent");
@@ -82,8 +82,8 @@
 	mw.isIpad3 = function () {
 		return  /OS 3_/.test(userAgent) && mw.isIpad();
 	};
-	mw.isIpadOnIos13 = function() {
-		return mw.isSafari() && mw.isTouchDevice();
+	mw.isIpadOS = function() {
+		return mw.isSafari() && !mw.isIphone() && mw.isTouchDevice();
 	};
 
 	// Note on those Android checks: Windows Phone browser has "Android" in its userAgent.

--- a/modules/MwEmbedSupport/mediawiki/mediawiki.client.js
+++ b/modules/MwEmbedSupport/mediawiki/mediawiki.client.js
@@ -8,7 +8,7 @@
 	var userAgent = navigator.userAgent;
 
 	mw.isMobileDevice = function () {
-		return ( mw.isIphone() || mw.isIpod() || mw.isIpad() || mw.isAndroid() || mw.isWindowsPhone() || mw.getConfig("EmbedPlayer.ForceNativeComponent") === true || mw.getConfig("EmbedPlayer.SimulateMobile") === true )
+		return ( mw.isIphone() || mw.isIpod() || mw.isIpad() || mw.isIpadOnIos13() || mw.isAndroid() || mw.isWindowsPhone() || mw.getConfig("EmbedPlayer.ForceNativeComponent") === true || mw.getConfig("EmbedPlayer.SimulateMobile") === true )
 	};
 	mw.isNativeApp = function () {
 		return mw.getConfig("EmbedPlayer.ForceNativeComponent");
@@ -82,7 +82,10 @@
 	mw.isIpad3 = function () {
 		return  /OS 3_/.test(userAgent) && mw.isIpad();
 	};
-	
+	mw.isIpadOnIos13 = function() {
+		return mw.isSafari() && mw.isTouchDevice();
+	};
+
 	// Note on those Android checks: Windows Phone browser has "Android" in its userAgent.
 	// https://msdn.microsoft.com/en-us/library/hh869301%28v=vs.85%29.aspx
 	// So the Android checks must make sure the string does not include "Windows".

--- a/modules/MwEmbedSupport/mediawiki/mediawiki.client.js
+++ b/modules/MwEmbedSupport/mediawiki/mediawiki.client.js
@@ -83,7 +83,7 @@
 		return  /OS 3_/.test(userAgent) && mw.isIpad();
 	};
 	mw.isIpadOS = function() {
-		return mw.isSafari() && !mw.isIphone() && mw.isTouchDevice();
+		return mw.isSafari() && !mw.isIphone() && !mw.isIpad() && mw.isTouchDevice();
 	};
 
 	// Note on those Android checks: Windows Phone browser has "Android" in its userAgent.

--- a/modules/unMuteOverlayButton/resources/unMuteOverlayButton.js
+++ b/modules/unMuteOverlayButton/resources/unMuteOverlayButton.js
@@ -61,7 +61,7 @@
                         .addClass('icon-volume-mute ' + this.getCssClass())
                         .html('<span>' + gM("mwe-embedplayer-unmute-label") + '</span>')
                         .click(function () {
-                            this.getPlayer().setVolume(this.playerVolume, null, mw.isIOS());
+                            this.getPlayer().setVolume(this.playerVolume, null, (mw.isIOS()|| mw.isIpadOnIos13()));
                         }.bind(this))
                         .hide()
                 }

--- a/modules/unMuteOverlayButton/resources/unMuteOverlayButton.js
+++ b/modules/unMuteOverlayButton/resources/unMuteOverlayButton.js
@@ -61,7 +61,7 @@
                         .addClass('icon-volume-mute ' + this.getCssClass())
                         .html('<span>' + gM("mwe-embedplayer-unmute-label") + '</span>')
                         .click(function () {
-                            this.getPlayer().setVolume(this.playerVolume, null, (mw.isIOS()|| mw.isIpadOnIos13()));
+                            this.getPlayer().setVolume(this.playerVolume, null, (mw.isIOS()|| mw.isIpadOS()));
                         }.bind(this))
                         .hide()
                 }


### PR DESCRIPTION
@OrenMe 

I made the the iPad on iOS 13 get recognized as a mobile device, see if that is ok.