### PR TITLE
fix(SUP-19782): Player fails when window.location.protocol is not set to http/https

### DIFF
--- a/kWidget/kWidget.js
+++ b/kWidget/kWidget.js
@@ -1065,7 +1065,10 @@
             	return protocolString;
 			} else {
             	try {
-                    return window.parent.location.protocol.slice(0, -1);
+            		protocolString = window.parent.location.protocol.slice(0, -1);
+					if (protocolString.match('^http')) {
+						return protocolString;
+					}
 				} catch (e){
                     this.log( "unable to get protocol for player request, assuming https" );
             		return "https";

--- a/kWidget/kWidget.js
+++ b/kWidget/kWidget.js
@@ -1064,12 +1064,7 @@
             if (protocolString.match('^http')) {
             	return protocolString;
 			} else {
-            	try {
-            		return "https";
-				} catch (e){
-                    this.log( "unable to get protocol for player request, assuming https" );
-            		return "https";
-				}
+				return "https";
 			}
 		},
 

--- a/kWidget/kWidget.js
+++ b/kWidget/kWidget.js
@@ -1065,10 +1065,7 @@
             	return protocolString;
 			} else {
             	try {
-            		protocolString = window.parent.location.protocol.slice(0, -1);
-					if (protocolString.match('^http')) {
-						return protocolString;
-					}
+            		return "https";
 				} catch (e){
                     this.log( "unable to get protocol for player request, assuming https" );
             		return "https";

--- a/resources/mediawiki/mediawiki.js
+++ b/resources/mediawiki/mediawiki.js
@@ -932,14 +932,9 @@ var mw = ( function ( $, undefined ) {
                 if (protocolString.match('^http')) {
                     return protocolString;
                 } else {
-                    try {
-                        return window.parent.location.protocol.slice(0, -1);
-                    } catch (e){
-                        mw.log( "unable to get protocol for load request, assuming https" );
                         return "https";
                     }
                 }
-            }
 
             function getPid() {
                 if (kalturaIframePackageData && kalturaIframePackageData.playerConfig && kalturaIframePackageData.playerConfig.widgetId) {


### PR DESCRIPTION
@OrenMe 
Per your suggestion I have added a regex check to the inner try.