### PR TITLE
fix(KMS-19979): Showing hint saves answer after edit for open-question

### DIFF
--- a/modules/Quiz/resources/quiz.js
+++ b/modules/Quiz/resources/quiz.js
@@ -559,9 +559,18 @@
                 .click(function () {
                     $(".close-button")
                     .click(function () {
-                        interfaceElement.find(".open-question-textarea").val(holdAnswer);
-                        interfaceElement.find(".open-question-chars .chars").text(holdAnswer.length);
-                        if (holdAnswer.length !== 0) {
+                        if (!cPo.isAnswerd) {
+                            interfaceElement.find(".open-question-textarea").val(holdAnswer);
+                            interfaceElement.find(".open-question-chars .chars").text(holdAnswer.length);
+                            if (holdAnswer.length !== 0) {
+                                interfaceElement.find("#open-question-clear,#open-question-save").removeAttr("disabled");
+                            }
+                        } else {
+                            interfaceElement.find(".open-question-textarea").val(holdAnswer);
+                            interfaceElement.find(".open-question-chars .chars").text(holdAnswer.length);
+                            interfaceElement.find(".ivqContainer.answered").removeClass("answered");
+                            interfaceElement.find("#open-question-change-answer").hide();
+                            interfaceElement.find(".open-question-textarea").removeAttr("disabled");
                             interfaceElement.find("#open-question-clear,#open-question-save").removeAttr("disabled");
                         }
                     })

--- a/modules/Quiz/resources/quiz.js
+++ b/modules/Quiz/resources/quiz.js
@@ -560,20 +560,18 @@
                     $(".close-button")
                     .click(function () {
                         if (!cPo.isAnswerd) {
-                            interfaceElement.find(".open-question-textarea").val(holdAnswer);
-                            interfaceElement.find(".open-question-chars .chars").text(holdAnswer.length);
+                            _this.setAnswer(holdAnswer);
                             if (holdAnswer.length !== 0) {
                                 interfaceElement.find("#open-question-clear,#open-question-save").removeAttr("disabled");
                             }
                         } else {
-                            interfaceElement.find(".open-question-textarea").val(holdAnswer);
-                            interfaceElement.find(".open-question-chars .chars").text(holdAnswer.length);
+                            _this.setAnswer(holdAnswer);
                             interfaceElement.find(".ivqContainer.answered").removeClass("answered");
                             interfaceElement.find("#open-question-change-answer").hide();
                             interfaceElement.find(".open-question-textarea").removeAttr("disabled");
                             interfaceElement.find("#open-question-clear,#open-question-save").removeAttr("disabled");
                         }
-                    })
+                    });
                 });
             });
 
@@ -1218,6 +1216,11 @@
         },
         isReflectionPoint: function(cPo){
             return cPo.questionType && cPo.questionType === this.KIVQModule.QUESTIONS_TYPE.REFLECTION_POINT;
+        },
+        setAnswer: function (answer) {
+            var interfaceElement = this.embedPlayer.getInterface();
+            interfaceElement.find(".open-question-textarea").val(answer);
+            interfaceElement.find(".open-question-chars .chars").text(answer.length);
         }
     }));
 })(window.mw, window.jQuery);

--- a/modules/Quiz/resources/quiz.js
+++ b/modules/Quiz/resources/quiz.js
@@ -555,6 +555,7 @@
             })
             .bind('change focusout', function(){
                 var holdAnswer = $(this).val();
+                var textAreaDisabled = $(this).prop('disabled');
                 interfaceElement.find(".hint-why-box")
                 .click(function () {
                     $(".close-button")
@@ -564,7 +565,7 @@
                             if (holdAnswer.length !== 0) {
                                 interfaceElement.find("#open-question-clear,#open-question-save").removeAttr("disabled");
                             }
-                        } else {
+                        } else if (!textAreaDisabled){
                             _this.setAnswer(holdAnswer);
                             interfaceElement.find(".ivqContainer.answered").removeClass("answered");
                             interfaceElement.find("#open-question-change-answer").hide();


### PR DESCRIPTION
in case where the user want to change his answer after he type the new text then open hint and close it the new text is saved automatically.

Added a logic, when the isAnswered is set to true, we display the edit mode.

P.S, the answer will get overridden only on the display not on the answer it self.