### PR TITLE
fix(SUP-20040): seek options are not synced

### DIFF
--- a/modules/Hlsjs/resources/hlsjs.js
+++ b/modules/Hlsjs/resources/hlsjs.js
@@ -794,14 +794,14 @@
 
 			_onseeking: function(){
 				// if this is the initial seeking which hls performs to the live edge - do nothing
-				if(this.afterInitialSeeking){
+				if(this.afterInitialSeeking || !this.embedPlayer.isLive()){
 					this.orig_onseeking();
 				}
 			},
 
 			_onseeked: function () {
 				// if this is the initial seeking which hls performs to the live edge - do nothing
-				if(this.afterInitialSeeking){
+				if(this.afterInitialSeeking || !this.embedPlayer.isLive()){
 					this.orig_onseeked();
 				}
 			},


### PR DESCRIPTION
@OrenMe 
Tested the matter with the LiveStats plugin and the original fix: FEC-6130
is still applicable.

We will have to test it against  the KMS as well.
