### PR TITLE
fix(SUP-19930): Captions are showing twice on inline iOS

### DIFF
--- a/modules/KalturaSupport/resources/mw.ClosedCaptions.js
+++ b/modules/KalturaSupport/resources/mw.ClosedCaptions.js
@@ -122,7 +122,7 @@
 					}
 				} );
 			} else {
-				this.bind( 'playing', function () {
+				this.bind( 'playing seeking', function () {
 					// hide native text tracks since 'showEmbeddedCaptions' is false
 					setTimeout(function () {
 						_this.embedPlayer.hideTextTrack();


### PR DESCRIPTION
When seeking, the Native Tracks are not removed.