### PR TITLE
fix(FEC-9507): Live stream audio is not initiated on Edge

### DIFF
--- a/modules/Hlsjs/resources/hlsjs.js
+++ b/modules/Hlsjs/resources/hlsjs.js
@@ -128,7 +128,7 @@
 					$(this.getPlayer().getPlayerElement()).one("canplay", function(){
 						// The initial seeking to the live edge has finished.
 						this.afterInitialSeeking = true;
-						if (this.embedPlayer.isLive() && mw.isIE11()) {
+						if (this.embedPlayer.isLive() && (mw.isIE11() || mw.isEdge())) {
 							var player = this.embedPlayer.getPlayerElement();
 							//nudge time on IE11 live streams due to audio bug https://github.com/video-dev/hls.js/issues/2323
 							player.currentTime = player.currentTime + 0.1;


### PR DESCRIPTION
Encounter the same issue that was occuring on IE 11 on SUP-16960 