### PR TITLE
fix(FEV-437): Unable to select from the menu when dualScreen is on

### DIFF
--- a/modules/KalturaSupport/components/dualScreen/dualScreenControlBar.css
+++ b/modules/KalturaSupport/components/dualScreen/dualScreenControlBar.css
@@ -2,7 +2,7 @@
     position: absolute;
     top: 0;
     right: 0;
-    z-index: 1003;
+    z-index: 999;
     padding: 24px 24px 0 0;
     cursor: pointer;
 }


### PR DESCRIPTION
When the DualScreen plugin is turned on, in some cases when the player size is small, we are unable to select from menus (Captions, SpeedSelectors etc).

Example:
https://www.kaltura.com/index.php/extwidget/preview/partner_id/2340551/uiconf_id/41078391/entry_id/0_2azz2r4a/embed/dynamic?&debugKalturaPlayer