### PR TITLE
fix(SUP-16764): Quiz.plugin pushes the captions up

### DIFF
--- a/modules/Quiz/resources/css/quiz.css
+++ b/modules/Quiz/resources/css/quiz.css
@@ -1086,11 +1086,6 @@ ol.second-row{
     top: 92vh;
     margin-left: 98%;
 }
-
-.track {
-    bottom:9vh!important;
-}
-
 .cp-navigation{
     float: right;
     width: 114px;


### PR DESCRIPTION
Per product decision, I have removed the caption repositioning when the quiz plugin is implemented.