### PR TITLE
fix(FEC-9593): Incorrect video size in player containing bumper/Ad

### DIFF
--- a/modules/KalturaSupport/resources/mw.ClosedCaptions.js
+++ b/modules/KalturaSupport/resources/mw.ClosedCaptions.js
@@ -40,6 +40,7 @@
 		updateLayoutEventFired: false,
 		ended: false,
         selectTextTrackTimeoutId: null,
+		isCaptionsShown: null,
 
 		setup: function(){
 			var _this = this;
@@ -228,6 +229,8 @@
 				}
 			});
 
+			this.isCaptionsShown = !!this.getConfig('displayCaptions');
+
 			if( this.getConfig('layout') === 'below'){
                 this.updateBelowVideoCaptionContainer();
 			}
@@ -244,11 +247,13 @@
 			}
 
 			this.bind("AdSupport_StartAdPlayback", function(){
-				_this.setConfig('displayCaptions', false);
-				_this.hideCaptions();
+				if (_this.isCaptionsShown) {
+					_this.setConfig('displayCaptions', false);
+					_this.hideCaptions();
+				}
 			});
 			this.bind("AdSupport_EndAdPlayback", function(){
-				if (_this.textSources >= 1) {
+				if (_this.isCaptionsShown) {
 					_this.setConfig('displayCaptions', true);
 					_this.showCaptions();
 				}
@@ -1108,7 +1113,7 @@
 			// Check if we even have textSources
 			if( sources == 0 ){
 				this.setConfig('displayCaptions', false);
-
+				this.isCaptionsShown = false;
 				if( this.getConfig('hideWhenEmpty') === true ) {
 					this.getBtn().hide();
 				}
@@ -1226,6 +1231,7 @@
 			this.embedPlayer.triggerHelper("selectClosedCaptions", "Off");
 			this.embedPlayer.triggerHelper('changedClosedCaptions', {language: ""});
 			this.setConfig('displayCaptions', false);
+			this.isCaptionsShown = false;
 			//Set the index of 'off' to lastActiveCaption
 			this.lastActiveCaption = this.getMenu().$el.find('.active').index();
 			this.getBtn().focus();
@@ -1268,6 +1274,7 @@
 			if( !this.getConfig('displayCaptions') ){
 				_this.getActiveCaption();
 				this.setConfig('displayCaptions', true );
+				this.isCaptionsShown = true;
 			}
 			// Save to cookie
 			if( setCookie && this.getConfig('useCookie') ){

--- a/modules/KalturaSupport/resources/mw.ClosedCaptions.js
+++ b/modules/KalturaSupport/resources/mw.ClosedCaptions.js
@@ -248,8 +248,10 @@
 				_this.hideCaptions();
 			});
 			this.bind("AdSupport_EndAdPlayback", function(){
-				_this.setConfig('displayCaptions', true);
-				_this.showCaptions();
+				if (_this.textSources >= 1) {
+					_this.setConfig('displayCaptions', true);
+					_this.showCaptions();
+				}
 			});
 			this.bind("playSegmentEvent", function(){
 				_this.updateTimeOffset();


### PR DESCRIPTION
The use-case: we set the `displayCaptions` to true even if the entry does not contains any captions.

I have added the `isCaptionsShown` that will determine if we want to show the captions or not.

Tested with Ads and Bumpers.