### PR TITLE
iPad bumper bug - Added missing condition for iPad/tablet:

### DIFF
--- a/modules/EmbedPlayer/resources/mw.MediaElement.js
+++ b/modules/EmbedPlayer/resources/mw.MediaElement.js
@@ -276,7 +276,7 @@ mw.MediaElement.prototype = {
 			var desktopVdn, mobileVdn;
 			$.each( vndSources, function( inx, source) {
 				// Kaltura tags vdn sources with iphonenew
-				if( source.getFlavorId() && source.getFlavorId().toLowerCase() == 'iphonenew' ){
+				if( source.getFlavorId() && source.getFlavorId().toLowerCase() == 'iphonenew' || source.getFlavorId().toLowerCase() == 'ipadnew'){
 					mobileVdn = source;
 				} else {
 					desktopVdn = source;


### PR DESCRIPTION
How to test:
go to: http://player.kaltura.com/docs/index.php?path=kvast
open devTools and select iPad;

This will cause bumper to hang and player will remain in frozen state...

Solution:
if( source.getFlavorId() && source.getFlavorId().toLowerCase() == 'iphonenew' || source.getFlavorId().toLowerCase() == 'ipadnew')

Add missing condition. For ipad all flavor sources were getting set from desktop sources NOT mobile sources.