### PR TITLE
fix(FEC-9626): adCuePoints do not work with cust_params

### DIFF
--- a/modules/DoubleClick/resources/mw.DoubleClick.js
+++ b/modules/DoubleClick/resources/mw.DoubleClick.js
@@ -333,8 +333,8 @@
         },
         parseAdTagUrlParts: function ( embedPlayer, pluginName ) {
             //Handle adTagUrl separately - using postProcessConfig on the entire ad tag breaks doubleclick functionality
-            var adTagUrl = embedPlayer.getRawKalturaConfig( pluginName, "adTagUrl" );
-            if ( adTagUrl ) {
+            var adTagUrl = embedPlayer.getRawKalturaConfig( pluginName, "adTagUrl" ) || this.adTagUrl;
+            if ( adTagUrl) {
                 try {
                     //Break url to base and query string.
                     var adTagUrlParts = adTagUrl.split( '?' );


### PR DESCRIPTION
Use case:
When user is implementing an Ad Cue point with a cust_param to the entry on a specific time frame, it does not getting recognized as the adTagUrl is hard coded to only listen to it on the flashvars level.

PS.
I didn't want to remove the original way we recognize the adTag since and just added to it.