### PR TITLE
fix(SUP-21019): Internet Explorer endless spinner in livestreams with DVR

### DIFF
--- a/modules/Hlsjs/resources/hlsjs.js
+++ b/modules/Hlsjs/resources/hlsjs.js
@@ -128,7 +128,7 @@
 					$(this.getPlayer().getPlayerElement()).one("canplay", function(){
 						// The initial seeking to the live edge has finished.
 						this.afterInitialSeeking = true;
-						if (this.embedPlayer.isLive() && (mw.isIE11() || mw.isEdge())) {
+						if (this.embedPlayer.isLive() && !this.embedPlayer.isDVR() && (mw.isIE11() || mw.isEdge())) {
 							var player = this.embedPlayer.getPlayerElement();
 							//nudge time on IE11 live streams due to audio bug https://github.com/video-dev/hls.js/issues/2323
 							player.currentTime = player.currentTime + 0.1;


### PR DESCRIPTION
Do not nudge the playback time when in DVR