### PR TITLE
fix(KMS-20622): Quiz bubbles are not showing when retaking quiz

### DIFF
--- a/modules/Quiz/resources/quiz.js
+++ b/modules/Quiz/resources/quiz.js
@@ -283,9 +283,11 @@
                 this.KIVQModule.setupQuiz().then(function(){
                     // new quiz data is now loaded - proceed with CPs loading 
                     _this.KIVQModule.getQuestionsAndAnswers(function(){
-                        _this.embedPlayer.stopPlayAfterSeek = false;
-                        _this.embedPlayer.seek(0,false);
-                        _this.ivqHideScreen()
+                        setTimeout(function () {
+                            _this.embedPlayer.stopPlayAfterSeek = false;
+                            _this.embedPlayer.seek(0,false);
+                            _this.ivqHideScreen()
+                        },50);
                     })
                 })
             }


### PR DESCRIPTION
The issue is with the way we call `$.cpObject.cpArray` [here](https://github.com/kaltura/mwEmbed/blob/28d148df7d6319cf10fee9360c0b1b34cedfb515/modules/Quiz/resources/quiz.js#L1165), this function is called before we initiate $.cpObject.cpArray [here](https://github.com/kaltura/mwEmbed/blob/c6c2f5d988d08a405abb862f1669c80e783f8351/modules/Quiz/resources/IVQModule.js#L270)  

I was able to observe the above while printing the content of them, using breakpoints will actually won't show the issue.