### PR TITLE
fix(SUP-21183): Icons are truncated on iPhone

### DIFF
--- a/modules/KalturaSupport/resources/mw.KBaseSmartContainer.js
+++ b/modules/KalturaSupport/resources/mw.KBaseSmartContainer.js
@@ -141,7 +141,9 @@
 			if ( numPlugins === 4 || numPlugins === 2){
 				pluginWidth = 50;
 			}
-			var pluginHeight = this.embedPlayer.getVideoHolder().width() / (numPlugins + 1);
+			var pluginHeight = !mw.isIOS()
+				? this.embedPlayer.getVideoHolder().width() / (numPlugins + 1)
+				: (this.embedPlayer.getVideoHolder().width() / (numPlugins));
 			$sc.find(".comp").not(".closePluginsScreen, .icon-next, .icon-prev, .largePlayBtn").width( pluginWidth + "%").height(pluginHeight);
 			$sc.removeClass("comp1 comp2 comp3 comp4 comp5 comp6").addClass("comp" + this.registeredPlugins.length);
 


### PR DESCRIPTION
This issue is related to a KMS use case, we do not calculate the height of the SmartContainer icons on iOS correctly and it causing the icons to truncate on iOS only.