### PR TITLE
fix(SUP-21282): No native fullscreen on iPad 12 and above

### DIFF
--- a/modules/EmbedPlayer/resources/mw.FullScreenManager.js
+++ b/modules/EmbedPlayer/resources/mw.FullScreenManager.js
@@ -143,7 +143,7 @@
 				screenfull.request(fsTarget, doc);
 			};
 			// Check for native support for fullscreen and we are in an iframe server
-			if( !this.fullScreenApiExcludes() && screenfull && screenfull.enabled(doc) && !mw.isOldAndroidChromeNativeBrowser()) {
+			if( !this.fullScreenApiExcludes() && screenfull && screenfull.enabled(doc) && !mw.isOldAndroidChromeNativeBrowser() && !mw.getConfig('EmbedPlayer.EnableIpadNativeFullscreen')) {
 				callFullScreenAPI();
 			} else {
 				if(!this.fullScreenApiExcludes() && mw.isAndroidChromeNativeBrowser()){


### PR DESCRIPTION
Tested the matter, and this is not a regression, I was able to reproduce this issue on older player versions as well.