### PR TITLE
fix(SUP-21601): Fullscreen is native when on desktop

### DIFF
--- a/modules/EmbedPlayer/resources/mw.FullScreenManager.js
+++ b/modules/EmbedPlayer/resources/mw.FullScreenManager.js
@@ -143,7 +143,7 @@
 				screenfull.request(fsTarget, doc);
 			};
 			// Check for native support for fullscreen and we are in an iframe server
-			if( !this.fullScreenApiExcludes() && screenfull && screenfull.enabled(doc) && !mw.isOldAndroidChromeNativeBrowser() && !mw.getConfig('EmbedPlayer.EnableIpadNativeFullscreen')) {
+			if( !this.fullScreenApiExcludes() && screenfull && screenfull.enabled(doc) && !mw.isOldAndroidChromeNativeBrowser() && !(mw.isIpad() || mw.isIpadOS())) {
 				callFullScreenAPI();
 			} else {
 				if(!this.fullScreenApiExcludes() && mw.isAndroidChromeNativeBrowser()){

--- a/modules/EmbedPlayer/resources/mw.FullScreenManager.js
+++ b/modules/EmbedPlayer/resources/mw.FullScreenManager.js
@@ -143,7 +143,7 @@
 				screenfull.request(fsTarget, doc);
 			};
 			// Check for native support for fullscreen and we are in an iframe server
-			if( !this.fullScreenApiExcludes() && screenfull && screenfull.enabled(doc) && !mw.isOldAndroidChromeNativeBrowser() && !(mw.isIpad() || mw.isIpadOS())) {
+			if( !this.fullScreenApiExcludes() && screenfull && screenfull.enabled(doc) && !mw.isOldAndroidChromeNativeBrowser() && !((mw.isIpad() || mw.isIpadOS()) && mw.getConfig('EmbedPlayer.EnableIpadNativeFullscreen'))) {
 				callFullScreenAPI();
 			} else {
 				if(!this.fullScreenApiExcludes() && mw.isAndroidChromeNativeBrowser()){


### PR DESCRIPTION
When `mw.getConfig('EmbedPlayer.EnableIpadNativeFullscreen` is set to true, it will affect also none iPad devices.

Regression fix of:
https://github.com/kaltura/mwEmbed/pull/4140
