### PR TITLE
fix(SUP-22116): Play Analytics not getting send for YT entries

### DIFF
--- a/modules/ExternalPlayers/resources/mw.EmbedPlayerYouTube.js
+++ b/modules/ExternalPlayers/resources/mw.EmbedPlayerYouTube.js
@@ -186,8 +186,8 @@
                     $(this).width("100%");
                     $(this).hide();
                     stateName = "playing";
-					//Add a trigger in order to comply with the kAnalony changes FEC-9424
-					this.triggerHelper('playing');
+		    //Add a trigger in order to comply with the kAnalony changes FEC-9424
+		    this.triggerHelper('playing');
                     // update duraiton
                     this.setDuration();
                     // trigger the seeked event only if this is seek and not in play

--- a/modules/ExternalPlayers/resources/mw.EmbedPlayerYouTube.js
+++ b/modules/ExternalPlayers/resources/mw.EmbedPlayerYouTube.js
@@ -186,6 +186,8 @@
                     $(this).width("100%");
                     $(this).hide();
                     stateName = "playing";
+					//Add a trigger in order to comply with the kAnalony changes FEC-9424
+					this.triggerHelper('playing');
                     // update duraiton
                     this.setDuration();
                     // trigger the seeked event only if this is seek and not in play


### PR DESCRIPTION
Due to changes on FEC-9424 we need to send 'playing' on the Yt analytics in order to pass PLAY and RESUME event.