### PR TITLE
fix(FEC-10114): jquery 3.0 breaks the player

### DIFF
--- a/kWidget/kWidget.js
+++ b/kWidget/kWidget.js
@@ -1093,11 +1093,11 @@
 					url: url,
 					data: requestData
 				})
-				.success(function (data) {
+				.done(function (data) {
 					var contentData = {content: data};
 					window[cbName](contentData);
 				})
-				.error(function (e) {
+				.fail(function (e) {
 					_this.log("Error in player iframe request")
 				})
 			} else {
@@ -1709,11 +1709,11 @@
 								dataType: 'text',
 								url: _this.getIframeUrl(),
 								data: _this.embedSettingsToUrl(settings)
-							}).success(function (data) {
+							}).done(function (data) {
 									var contentData = {content: data};
 									window[cbName](contentData);
 								})
-								.error(function (e) {
+								.fail(function (e) {
 									_this.log("Error in player iframe request");
 							});
 						}else{


### PR DESCRIPTION
replace `success/error` to `done/fail` see https://jquery.com/upgrade-guide/3.0/#breaking-change-special-case-deferred-methods-removed-from-jquery-ajax
This changed is required only in the embed code since the player itself is running in an iframe and uses own its own jquery (1.11.1)