### PR TITLE
fix(SUP-24147):  player displaying captions for entry even if the captions plugin is disabled

### DIFF
--- a/modules/KalturaSupport/components/dualScreen/dualScreen.js
+++ b/modules/KalturaSupport/components/dualScreen/dualScreen.js
@@ -269,6 +269,15 @@
 				this.bind( 'onplay', function () {
 						if (!isOverlayScreenOpen && _this.canManipulateControlViews()) {
 							_this.controlBar.enable();
+							// Added this in order to remove the Embedded Captions that are showing on the second screen
+							// As the HLSjs is only disabling it for the main player
+							if (!_this.embedPlayer.getKalturaConfig('closedCaptions', 'showEmbeddedCaptions')) {
+								var vid = _this.secondPlayer.playerElement;
+								var textTracks = vid.textTracks;
+								for (var i=0; i < textTracks.length; i++){
+									textTracks[i].mode = "disabled";
+								}
+							}
 						}
 				} );
 				this.bind( 'onpause ended playerReady', function () {


### PR DESCRIPTION
@eitanavgil 
The textTrack on the second screen should be disabled as well.