### PR TITLE
fix(FEV-772): reverted SUP-16764

### DIFF
--- a/modules/Quiz/resources/quiz.js
+++ b/modules/Quiz/resources/quiz.js
@@ -77,8 +77,6 @@
                             embedPlayer.hideSpinner();
                             _this.KIVQModule.unloadQuizPlugin(embedPlayer);
                             embedPlayer.enablePlayControls();
-                            $("link[href$='quiz.css']")[0].removeAttr('disabled');
-                            $("link[href$='quizFonts.css']")[0].removeAttr('disabled');
                         })
                         .done(function(data) {
                             var ivqNotificationData = {
@@ -133,8 +131,6 @@
                     }
                 }
                 else{
-                    $("link[href$='quiz.css']")[0].setAttribute('disabled','disabled');
-                    $("link[href$='quizFonts.css']")[0].setAttribute('disabled','disabled');
                     _this.KIVQModule.unloadQuizPlugin(embedPlayer);
                     embedPlayer.enablePlayControls();
                     if(_this.KIVQModule.isKPlaylist){


### PR DESCRIPTION
@eitanavgil 
The quiz.css and the quizFonts.css are only available when we are on debugKalturaPlayer mode, which can explain why I was unable to see this issue while debugging locally, so basically the entire logic of the initial fix is not applicable so no reason to have this fix.