### PR TITLE
fix(FEC-11111): images remain static according to their dimensions

### DIFF
--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerImageOverlay.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerImageOverlay.js
@@ -294,7 +294,7 @@
 			});
 
 			// Add the image before the video element or before the playerInterface
-			if (!_this.imageLoaded) {
+			if (!this.imageLoaded) {
 				$( this ).html( $image );
 			}
 

--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerImageOverlay.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerImageOverlay.js
@@ -294,7 +294,9 @@
 			});
 
 			// Add the image before the video element or before the playerInterface
-			$( this ).html( $image );
+			if (!_this.imageLoaded) {
+				$( this ).html( $image );
+			}
 
 		},
 		/**


### PR DESCRIPTION
When entering a full screen and the entry is type of image- the image remains static according to its dimensions, rather than stretch according to full screen dimensions.

solution: in embedPlayerHTML func- updating the image only if the image hasn't been loaded yet.

Solves [FEC-11111](https://kaltura.atlassian.net/browse/FEC-11111).