### PR TITLE
fix(FEC-11158): accessibility in Video quiz - can't reach continue button using keyboard

### DIFF
--- a/modules/Quiz/resources/quiz.js
+++ b/modules/Quiz/resources/quiz.js
@@ -1075,7 +1075,7 @@
             if (_this.KIVQModule.quizSubmitted) {
                 $(".ftr-right").html(gM('mwe-quiz-next')).on('click', function () {
                     _this.KIVQModule.continuePlay();
-                }).on('keydown', _this.keyDownHandler).attr({'tabindex': 6.3, "role" : "button"});
+                }).on('keydown', _this.keyDownHandler).attr({'tabindex': 5, "role" : "button"});
                 return;
             }
             if (_this.KIVQModule.reviewMode) {
@@ -1096,7 +1096,7 @@
                     }else{
                         _this.KIVQModule.continuePlay();
                     }
-                }).attr({'tabindex': 6.3, "role" : "button"}).on('keydown', _this.keyDownHandler);
+                }).attr({'tabindex': 5, "role" : "button"}).on('keydown', _this.keyDownHandler);
             } else {
                 $(".ftr-left").append($('<p id="ftr-question">' + gM('mwe-quiz-question') + ' ' + this.KIVQModule.i2q(questionNr)
                 + '/' + $.cpObject.cpArray.length + '</p>')


### PR DESCRIPTION
Issue:
in IVQ, when in submit mode or review mode, can't reach "continue" button using "tab" in keybaord.

Solution: 
changing tabindex=6.3 to tabindex=5 in continue btn element.

Solves FEC-11158