### PR TITLE
fix(FEC-11239): black bars upon exiting full screen

### DIFF
--- a/modules/KalturaSupport/resources/mw.KBaseMediaList.js
+++ b/modules/KalturaSupport/resources/mw.KBaseMediaList.js
@@ -144,6 +144,10 @@
 		},
 		// set the play list container according to the selected position
 		getMedialistContainer: function(){
+			if (this.playlistSet.length === 0) {
+				this.$mediaListContainer = $();
+				return this.$mediaListContainer;
+			}
 			if (!this.$mediaListContainer) {
 					if (this.getConfig('onPage')) {
 						var iframeID = this.embedPlayer.id + '_ifp';


### PR DESCRIPTION
issue:
when playing entry using playlist player and exiting full screen - empty playlist container is displayed.

solution:
calculating width of playback only if there are playlists in the playlistSet.

Solves FEC-11239