### PR TITLE
fix(FEC-11252): caption with displayOnPlayer off doesn't work properly in playlist

### DIFF
--- a/modules/KalturaSupport/resources/mw.ClosedCaptions.js
+++ b/modules/KalturaSupport/resources/mw.ClosedCaptions.js
@@ -551,6 +551,8 @@
 					}
 					callback( captions );
 				} );
+			} else {
+				callback([]);
 			}
 		},
 		sortByKey: function ( array, key ) {


### PR DESCRIPTION
issue:
when creating a playlist and for some of the entries in it the "DisplayOnPlayer" for the captions is disabled, and you move from an entry with DisplayOnPlayer=true to an entry with DisplayOnPlayer=false - the captions of previous entry show up on current entry and kind of stuck.
The expected behavior is to not show captions at all and btn of CC also should not be displayed.

solution:
as part of the flow, adding a callback([]) with empty captions array.

Solves FEC-11252.