### PR TITLE
fix(FEC-11256): video controls are not clickable on IOS when captureClickEventForiOS flag is used

### DIFF
--- a/kWidget/kWidget.js
+++ b/kWidget/kWidget.js
@@ -1285,6 +1285,7 @@
 				'<body>' +
 				'<div class="mwPlayerContainer"  style="width: 100%; height: 100%">' +
 				'<div class="videoHolder">' +
+				'<div class="videoDisplay">' +
 				'<video class="persistentNativePlayer" ' +
 				'id="' + targetId + '" ' +
 				'kwidgetid="' + settings.wid + '" ' +
@@ -1297,6 +1298,7 @@
 				'style="width:100%;height:100%" ' +
 				'>' +
 				'</video>' +
+				'</div>' +
 				'</div>' +
 				'</div>' +
 				// issue play on the silent black video ( to capture iOS gesture )


### PR DESCRIPTION
the issue:
when playing media in IOS and captureClickEventForIOS flag is set to true, the native ios controls are not working.
when captureClickEventForIOS flag is set to true, there is re-writing of the video element. seems like "videoDisplay" div was forgotten and as a result, the hierarchy in DOM was changed.

the solution:
added videoDisplay div before video element, so the hierarchy will be the same as when the flag is disabled.