### PR TITLE
fix(FEC-11271):displaying .VTT captions not working properly for below video layout

### DIFF
--- a/modules/KalturaSupport/resources/mw.ClosedCaptions.js
+++ b/modules/KalturaSupport/resources/mw.ClosedCaptions.js
@@ -775,7 +775,12 @@
 					.css('pointer-events', 'auto')
 					.css('z-index', '3')
 					.css('pointer-events', 'none')
+					.css('position', 'relative')
 				);
+
+			if (this.getConfig('layout') === 'below') {
+				$(caption.content).css('inset', '0px');
+			}
 
 			this.displayTextTarget($textTarget);
 


### PR DESCRIPTION
Issue:
when setting the captions layout to "below video" and playing .vtt captions- the captions are placed on the video as "on top" layout, instead of inside the container below the video.

Solution:
forcing inset=0 when layout=below video. In addition, added position=relative to parent class so captions will be placed according to the caption container and not to the video holder.

Solves FEC-11271