### PR TITLE
fix(FEC-11282): cannot read property 'capabilities' of null

### DIFF
--- a/modules/Quiz/resources/quiz.js
+++ b/modules/Quiz/resources/quiz.js
@@ -64,7 +64,7 @@
                 _this.KIVQModule = new mw.KIVQModule(embedPlayer, _this);
                 _this.KIVQModule.isKPlaylist = (typeof (embedPlayer.playlist) === "undefined" ) ? false : true;
 
-                if (embedPlayer.kalturaPlayerMetaData.capabilities === "quiz.quiz"){
+                if (embedPlayer.kalturaPlayerMetaData && embedPlayer.kalturaPlayerMetaData.capabilities === "quiz.quiz"){
                     if (embedPlayer.autoplay) {
                         mw.setConfig('autoPlay', false);
                         embedPlayer.autoplay = false;


### PR DESCRIPTION
**issue:**
when kalturaPlayerMetadata is null, there is an error when checking kalturaPlayerMetadata.capabilities.

**solution:**
checking first if kalturaPlayerMetadata is not null

solves FEC-11282