### PR TITLE
fix(FEC-11232): styles for "I understand" button

### DIFF
--- a/modules/Quiz/resources/css/quiz.css
+++ b/modules/Quiz/resources/css/quiz.css
@@ -799,7 +799,8 @@ button.qContinue, button.qApplied {
 }
 .gotItBox{
     border-radius: 4px;
-    width: 15vw;
+    padding: 0 4px;
+    min-width: 15vw;
     height: 8vh;
     line-height: 8vh;
     font-weight: 700;


### PR DESCRIPTION
Changes approved by Ido Achrak
<img width="154" alt="Screen Shot 2021-06-01 at 5 41 24 PM" src="https://user-images.githubusercontent.com/51074448/120343116-1c2c9700-c301-11eb-8d47-99b4af93e1fb.png">
<img width="150" alt="Screen Shot 2021-06-01 at 5 40 56 PM" src="https://user-images.githubusercontent.com/51074448/120343120-1d5dc400-c301-11eb-8165-12f64a33b77d.png">
<img width="164" alt="Screen Shot 2021-06-01 at 5 39 27 PM" src="https://user-images.githubusercontent.com/51074448/120343126-1d5dc400-c301-11eb-9af4-240593b2fe4d.png">
<img width="157" alt="Screen Shot 2021-06-01 at 5 39 09 PM" src="https://user-images.githubusercontent.com/51074448/120343129-1df65a80-c301-11eb-8eac-ef2d242890f6.png">
<img width="200" alt="Screen Shot 2021-06-01 at 5 38 54 PM" src="https://user-images.githubusercontent.com/51074448/120343130-1e8ef100-c301-11eb-8049-07ab32f307e0.png">
