### PR TITLE
fix(FEC-11373): blank space in QnA area when onPage is false

### DIFF
--- a/modules/QnA/resources/qna.js
+++ b/modules/QnA/resources/qna.js
@@ -524,6 +524,7 @@
 
 				if (!_this.getConfig( 'onPage' )) {
 					_this.getQnaContainer().find(".qnaModuleBackgroundHider").hide();
+					_this.getQnaContainer().find(".qnaModuleBackground").show();
 				}
 				// open the module only if this is the first time
 				if (firstTime) {


### PR DESCRIPTION
**issue:**
when qna.onPage=false and the qna is enabled via the webcasting app, there is an empty black container, instead of the qna layout. The reason for this behavior is that the display att of the relevant element stays with "none" value, and never being changed to "block".

**solution:**
adding call to show() on the relevant element where needed.

Solves FEC-11373