### PR TITLE
fix(SUP-28319): prevent focus chapters when side panel closed

### DIFF
--- a/modules/KalturaSupport/components/chapters/chapters.css
+++ b/modules/KalturaSupport/components/chapters/chapters.css
@@ -20,6 +20,17 @@
 .searchFormWrapper :-moz-placeholder {
     color: #595959;
 }
+.sideBarContainer.openBtn .chapters {
+    visibility: visible;
+}
+.sideBarContainer:not(.openBtn) .chapters {
+	visibility: hidden;
+	-webkit-transition: visibility 0.3s;
+	-moz-transition: visibility 0.3s;
+	-o-transition: visibility 0.3s;
+	-ms-transition: visibility 0.3s;
+	transition: visibility 0.3s;
+}
 .chapters .unselectable {
     -moz-user-select: -moz-none;
     -khtml-user-select: none;

--- a/modules/KalturaSupport/components/chapters/chapters.js
+++ b/modules/KalturaSupport/components/chapters/chapters.js
@@ -1294,6 +1294,19 @@
 					}
 				}
 			});
+			this.handleHomeEndKeys = function (e) {
+				if(e.keyCode === 35) {
+					// end key pressed
+					e.stopPropagation();
+					this.getMediaListDomElements().filter( ".chapterBox" ).last().focus();
+				}
+				if(e.keyCode === 36) {
+					// home key pressed
+					e.stopPropagation();
+					this.getMediaListDomElements().filter( ".chapterBox" ).first().focus();
+				}
+			};
+
 			this.onItemKey = function (e) {
 				var _this = this;
                 if(e.keyCode === 13){
@@ -1311,10 +1324,12 @@
             };
 
 			var mediaBoxes = this.getMediaListDomElements();
-			mediaBoxes.on('mousedown mouseup mouseout', function(){
-				this.blur();
-			})
-			.on('keyup', $.proxy(this.onItemKey , this));
+			mediaBoxes
+				.on('mousedown mouseup mouseout', function(){
+					this.blur();
+				})
+				.on('keydown', $.proxy(this.handleHomeEndKeys, this))
+				.on('keyup', $.proxy(this.onItemKey , this));
 
 			this.getComponent().find(".slideBoxToggle")
 					.off("click").on("click", function(e){


### PR DESCRIPTION
1) use css property "visibility: hidden" to prevent tabbing into closed sidebar panel;
2) handle "home"\"end" keys for navigation to first\last chapter(slide)