### PR TITLE
fix(FEC-11542): tooltips in full screen don't pop out when hovering over it

### DIFF
--- a/modules/KalturaSupport/components/playPauseBtn.js
+++ b/modules/KalturaSupport/components/playPauseBtn.js
@@ -44,7 +44,10 @@
 			});
                 this.bind('onOpenFullScreen', function () {
                     try {
-                    _this.getComponent().focus();
+						setTimeout(function () {
+							_this.getComponent().focus();
+						}, 250);
+
                     } catch(e){}
                 });
 

--- a/skins/kdark/css/layout.css
+++ b/skins/kdark/css/layout.css
@@ -1320,7 +1320,7 @@ body {
 	background: -ms-linear-gradient(top, #000000, #000000);
 	background: linear-gradient(top, #000000, #000000);
 
-	z-index: 1000;
+	z-index: 9999;
 	font-weight: bold;
 	font-size: 0.85em;
 	letter-spacing: 0px;


### PR DESCRIPTION
**the issue:**
when in fullscreen, tooltips of bottom bar buttons are not displayed.

**solution:**
increase z-index of tooltips to 9999, as player ins fullscreen is having z-index=9999.
also had to delay the focus of play/pause btn when entering fullscreen, to prevent from the tooltip to appear in a wrong place.

Solves FEC-11542