### PR TITLE
fix(FEC-11774): dual screen constant shadowed layer appears

### DIFF
--- a/modules/KalturaSupport/components/dualScreen/dualScreen.css
+++ b/modules/KalturaSupport/components/dualScreen/dualScreen.css
@@ -155,7 +155,7 @@
     visibility: visible;
     opacity: 1;
 }
-.dualScreen.componentOff *{
+.dualScreen.componentOff {
     visibility: hidden;
     opacity: 0;
 }


### PR DESCRIPTION
**the issue:**
when using the mouse to hover away from the player, the contrast shadow of dual screen controls doesn't disappear.

**solution:**
there is a css that is handling this scenario, however the style is not applied. removing "*" from .dualscreen.componentOff

Solves FEC-11774