### PR TITLE
fix(FEC-11791): share url has cross-site scripting vulnerability

### DIFF
--- a/modules/KalturaSupport/components/share/share.js
+++ b/modules/KalturaSupport/components/share/share.js
@@ -616,7 +616,8 @@
 					res = document.URL;
 				}
 			}
-			return kWidget.sanitize(decodeURIComponent(res));
+			var sanitized = kWidget.sanitize(decodeURIComponent(res));
+			return encodeURIComponent(sanitized);
 		}
 		// -------------- finish setup player url according to the socialShareURL flashvar ------- //
 

--- a/modules/KalturaSupport/components/share/share.js
+++ b/modules/KalturaSupport/components/share/share.js
@@ -616,7 +616,7 @@
 					res = document.URL;
 				}
 			}
-			return res;
+			return kWidget.sanitize(decodeURIComponent(res));
 		}
 		// -------------- finish setup player url according to the socialShareURL flashvar ------- //
 


### PR DESCRIPTION
**description of the issue:**
when share plugin is enabled for the player, the share url is not being sanitized, which exposes a security vulnerability.

**the solution:**
sanitizing encoded and decoded share url.

Solves FEC-11791