### PR TITLE
fix(FEC-11887): qna container is not visible on embedded player by default if the uivar “Kaltura.ForceLayoutRedraw” is set to true

### DIFF
--- a/modules/EmbedPlayer/resources/mw.EmbedPlayer.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayer.js
@@ -305,6 +305,9 @@
 
 		liveSyncDurationOffset:0,
 
+		// if the player should keep its responsivness
+		shouldKeepResponsivness: true,
+
 		/**
 		 * embedPlayer
 		 *
@@ -1865,9 +1868,12 @@
 						height: this.getInterface().height() + 1
 					};
 					this.updateInterfaceSize(resize);
-					resize.height = "100%";
-					resize.width = "100%";
-					this.updateInterfaceSize(resize);
+
+					if (this.shouldKeepResponsivness) {
+						resize.height = "100%";
+						resize.width = "100%";
+						this.updateInterfaceSize(resize);
+					}
 				}
 				this.triggerHelper('widgetLoaded');
 			}

--- a/modules/EmbedPlayer/resources/mw.EmbedPlayer.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayer.js
@@ -305,9 +305,6 @@
 
 		liveSyncDurationOffset:0,
 
-		// if the player should keep its responsivness
-		shouldKeepResponsivness: true,
-
 		/**
 		 * embedPlayer
 		 *
@@ -1869,7 +1866,8 @@
 					};
 					this.updateInterfaceSize(resize);
 
-					if (this.shouldKeepResponsivness) {
+					var qnaPlugin = this.getPluginInstance("qna");
+					if (!qnaPlugin || qnaPlugin.getConfig("onPage")) {
 						resize.height = "100%";
 						resize.width = "100%";
 						this.updateInterfaceSize(resize);

--- a/modules/QnA/resources/qna.js
+++ b/modules/QnA/resources/qna.js
@@ -276,6 +276,7 @@
 					// resize the video to make place for the playlist according to its position (left, top, right, bottom)
 					if ( this.getConfig( 'containerPosition' ) === 'right' || this.getConfig( 'containerPosition' ) === 'left' ) {
 						$( ".videoHolder, .mwPlayerContainer" ).css( "width", $( ".videoHolder").width() - this.getConfig( 'moduleWidth' ) + "px" );
+						embedPlayer.shouldKeepResponsivness = false;
 					}
 
 					if ( this.getConfig( 'containerPosition' ) === 'left' ) {

--- a/modules/QnA/resources/qna.js
+++ b/modules/QnA/resources/qna.js
@@ -276,7 +276,6 @@
 					// resize the video to make place for the playlist according to its position (left, top, right, bottom)
 					if ( this.getConfig( 'containerPosition' ) === 'right' || this.getConfig( 'containerPosition' ) === 'left' ) {
 						$( ".videoHolder, .mwPlayerContainer" ).css( "width", $( ".videoHolder").width() - this.getConfig( 'moduleWidth' ) + "px" );
-						embedPlayer.shouldKeepResponsivness = false;
 					}
 
 					if ( this.getConfig( 'containerPosition' ) === 'left' ) {


### PR DESCRIPTION
**the issue:**
this is a regression caused by SUP-11362.
when uivar Kaltura.ForceLayoutRedraw=true and using qna plugin where onPage=false, the qna container is not visible when the player is loaded.

**the solution:**
executing the responsive action that was added by SUP-11362 only in 2 cases:
1. when there is no qna plugin/disabled.
2. if qna plugin exists and enabled, then only when onPage=true.

Solves FEC-11887