### PR TITLE
fix(FEC-11992): v2 - Unsupported source type error received on iPhone when using shaka

### DIFF
--- a/modules/Dash/resources/dash.js
+++ b/modules/Dash/resources/dash.js
@@ -16,6 +16,7 @@
 	}
 
 	if (shaka.Player.isBrowserSupported() &&
+		!mw.isIOS() &&
 		!mw.getConfig("EmbedPlayer.ForceNativeComponent") &&
 		!mw.isDesktopSafari() &&
 		!mw.isAndroid()) {


### PR DESCRIPTION
**the issue:**
when trying to play dash on ios it fails with "unsupported source type" error from shaka.

**root cause:**
player v2 version 2.86 was upgrading shaka version from 2.3.2 to 2.5.19.
according to the following link [isBrowserSupported for iOSTYPE: QUESTION](https://github.com/google/shaka-player/issues/2100) shaka returned false for isBrowserSupported on ios, then on version 2.5 isBrowserSupported() returned true for ios.

**solution:**
add !isIOS when registering shaka.

Solves FEC-11992