### PR TITLE
fix(FEC-12016): poll responses is showing 0 after toggling between the 'Hide/Show' button within the Webcasting App

### DIFF
--- a/modules/WebcastPolls/resources/webcastPolls.js
+++ b/modules/WebcastPolls/resources/webcastPolls.js
@@ -283,10 +283,6 @@
 						            _this.pollData.pollResults.totalVoters = cuepointContent.totalVoters;
 						            _this.view.syncDOMPollResults();
 					            }
-                                // kCuePoint filter is sorting according to startTime - cuepoint has start time 0
-                                cuepoint.startTime = cuepoint.createdAt * 1000;
-                                // need to save poll-results cuepoints in case we reset internal data
-                                _this.getPlayer().kCuePoints.updateCuePoints([cuepoint]);
                                 // make sure we process poll-results cuepoint
                                 var newContext = _this.cuePointsManager._createReachedCuePointsArgs([cuepoint] , {} );
                                 _this.handlePollResultsCuePoints({cuepointsArgs : newContext});
@@ -308,6 +304,9 @@
 			            }
 
 		            }
+                    // update and save poll-results cuepoints
+                    _this.getPlayer().kCuePoints.fixLiveCuePointArray(cuepoints);
+                    _this.getPlayer().kCuePoints.updateCuePoints(cuepoints);
 	            } , [pushSystemName]);
 
                 _this.cuePointsManager.onCuePointsReached = $.proxy(function(args)

--- a/modules/WebcastPolls/resources/webcastPolls.js
+++ b/modules/WebcastPolls/resources/webcastPolls.js
@@ -283,7 +283,11 @@
 						            _this.pollData.pollResults.totalVoters = cuepointContent.totalVoters;
 						            _this.view.syncDOMPollResults();
 					            }
-                                // make sure we process poll-results cuepoint 
+                                // kCuePoint filter is sorting according to startTime - cuepoint has start time 0
+                                cuepoint.startTime = cuepoint.createdAt * 1000;
+                                // need to save poll-results cuepoints in case we reset internal data
+                                _this.getPlayer().kCuePoints.updateCuePoints([cuepoint]);
+                                // make sure we process poll-results cuepoint
                                 var newContext = _this.cuePointsManager._createReachedCuePointsArgs([cuepoint] , {} );
                                 _this.handlePollResultsCuePoints({cuepointsArgs : newContext});
                             }


### PR DESCRIPTION
**the issue:**
the scenario:
1. presenter is creating poll
2. users are voting
3. presenter clicks on hide via webcasting app
4. presenter clicks on show via webcasting app

expected behavior -> player displays the correct amount of responses (totalVoters)
observed behavior -> player is displaying 0 responses

**root cause:**
player is not saving poll-results cuepoints, which contains the total voters value. since hide is resetting the local data, when clicking on show, the player is displaying 0 responses.

**the solution:**
when player is receiving poll-results cuepoint, we should save it.

Solves FEC-12016