### PR TITLE
fix(FEC-12080): slides do not appear in dual screen in VOD webcast

### DIFF
--- a/modules/WebcastPolls/resources/webcastPolls.js
+++ b/modules/WebcastPolls/resources/webcastPolls.js
@@ -305,8 +305,10 @@
 
 		            }
                     // update and save poll-results cuepoints
-                    _this.getPlayer().kCuePoints.fixLiveCuePointArray(cuepoints);
-                    _this.getPlayer().kCuePoints.updateCuePoints(cuepoints);
+                    if (_this.embedPlayer.isLive()) {
+                        _this.getPlayer().kCuePoints.fixLiveCuePointArray(cuepoints);
+                        _this.getPlayer().kCuePoints.updateCuePoints(cuepoints);
+                    }
 	            } , [pushSystemName]);
 
                 _this.cuePointsManager.onCuePointsReached = $.proxy(function(args)


### PR DESCRIPTION
**the issue:**
following a fix in [FEC-12016](https://github.com/kaltura/mwEmbed/pull/4259) , slides do not appear in dualscreen in the recorded VOD.

**solution:**
call fixLiveCuePointArray and updateCuePoints only if in live state.

Solves FEC-12080