### PR TITLE
fix(FEC-12182): playlist player not showing VTT captions when dualscreen plugin is enabled

### DIFF
--- a/modules/KalturaSupport/resources/mw.ClosedCaptions.js
+++ b/modules/KalturaSupport/resources/mw.ClosedCaptions.js
@@ -793,6 +793,9 @@
 
 			// vtt.js calculates the caption layout assuming margin of 1.5%
 			this.getCaptionsOverlay().css('margin', '1.5%');
+
+			// position needs to be absolute so other elements won't affect the captions position
+			this.getCaptionsOverlay().css('position', 'absolute');
 		},
 
 		addCaptionAsText: function ( source, capId, caption ) {


### PR DESCRIPTION
**the issue:**
vtt captions are not shown in playlist player when dualscreen plugin is enabled.

**root cause:**
dualscreen plugin is creating a DOM element which is "pushing" down the captions. unlike srt, vtt has inset values and the player is rendering vtt captions differently than srt. the dualscreen related DOM element doesn't affect the srt captions.

**solution:**
set position=absolute on captionsOverlay, when rendering vtt. this way the captionsOverlay container will not be interfered by other elements. 

Solves FEC-12182