### PR TITLE
fix(FEC-12183): chapter and slides have wrong thumbnails

### DIFF
--- a/modules/KalturaSupport/resources/mw.KBaseMediaList.js
+++ b/modules/KalturaSupport/resources/mw.KBaseMediaList.js
@@ -426,7 +426,7 @@
 			var thumbUrl = kWidgetSupport.getKalturaThumbnailUrl(
 				$.extend( {}, this.baseThumbSettings, {
                     'url': this.embedPlayer.evaluate('{mediaProxy.entry.thumbnailUrl}'),
-					'vid_sec': parseInt( time / 1000 )
+					'vid_sec': time / 1000
 				} )
 			);
 			return thumbUrl;


### PR DESCRIPTION
**the issue:**
chapters show wrong thumbnail. when clicking on a thumbnail, we jump to a point in the video where the thumbnail is different from the chapter's thumbnail.

**root cause:**
player is doing parseInt to time/1000, therefore, the time is less accurate (i.e. 118.123 becomes 118). in V7 we send time/1000 w/o parsing it to int or changing the value.

**solution:**
remove parseInt and leave the time value as accurate as it can be.

Solves FEC-12183