### PR TITLE
fix(FEC-12230): VTT Captions are covered up by player controls when Hover mode enabled

### DIFF
--- a/modules/KalturaSupport/resources/mw.ClosedCaptions.js
+++ b/modules/KalturaSupport/resources/mw.ClosedCaptions.js
@@ -782,6 +782,13 @@
 				$(caption.content).css('inset', '0px');
 			}
 
+			if (this.getPlayer().isOverlayControls() && this.embedPlayer.getKalturaConfig( 'controlBarContainer', 'hover')
+				&& this.getConfig('layout') === 'ontop'){
+				$textTarget.css('bottom', this.defaultBottom);
+				$textTarget.css('position', 'absolute');
+				$(caption.content).css('inset', '0px');
+			}
+
 			this.displayTextTarget($textTarget);
 
 			var captionDiv = $('.caption div');


### PR DESCRIPTION
**the issue:** 
when player's bottom bar controls has hover mode enable and the captions are vtt type, the bottom bar is overlaying the captions. 

**the solution:** 
when hover mode in enable and closed caption's layout is ontop, changing some css attributes which  allows the captions to behave as expected.

solves FEC-12230 