### PR TITLE
fix(FEC-12267): Fix XSS Vulnerability in mwEmbed - enforce valid domain format

### DIFF
--- a/includes/DefaultSettings.php
+++ b/includes/DefaultSettings.php
@@ -5,8 +5,8 @@
  * DO NOT MODIFY THIS FILE. Instead modify LocalSettings.php in the parent mwEmbd directory.
  *
  */
-
-if (isset($_SERVER["HTTP_X_FORWARDED_HOST"]))
+$VALID_HOSTNAME_PATTERN = "/^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$/";
+if (isset($_SERVER["HTTP_X_FORWARDED_HOST"]) && preg_match($VALID_HOSTNAME_PATTERN, $_SERVER["HTTP_X_FORWARDED_HOST"]) === 1)
 {
     // support multiple hosts (comma separated) in HTTP_X_FORWARDED_HOST
     $xForwardedHosts = explode(',', $_SERVER['HTTP_X_FORWARDED_HOST']);

--- a/includes/DefaultSettings.php
+++ b/includes/DefaultSettings.php
@@ -5,6 +5,7 @@
  * DO NOT MODIFY THIS FILE. Instead modify LocalSettings.php in the parent mwEmbd directory.
  *
  */
+
 if (isset($_SERVER["HTTP_X_FORWARDED_HOST"]))
 {
     // support multiple hosts (comma separated) in HTTP_X_FORWARDED_HOST

--- a/includes/DefaultSettings.php
+++ b/includes/DefaultSettings.php
@@ -5,13 +5,16 @@
  * DO NOT MODIFY THIS FILE. Instead modify LocalSettings.php in the parent mwEmbd directory.
  *
  */
-$VALID_HOSTNAME_PATTERN = "/^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$/";
-if (isset($_SERVER["HTTP_X_FORWARDED_HOST"]) && preg_match($VALID_HOSTNAME_PATTERN, $_SERVER["HTTP_X_FORWARDED_HOST"]) === 1)
+if (isset($_SERVER["HTTP_X_FORWARDED_HOST"]))
 {
     // support multiple hosts (comma separated) in HTTP_X_FORWARDED_HOST
     $xForwardedHosts = explode(',', $_SERVER['HTTP_X_FORWARDED_HOST']);
-    $_SERVER["HTTP_HOST"] = $xForwardedHosts[0];
-    $_SERVER["SERVER_NAME"] = $xForwardedHosts[0];
+    $VALID_HOSTNAME_PATTERN = "/^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$/";
+    if (preg_match($VALID_HOSTNAME_PATTERN, $xForwardedHosts[0]) === 1)
+    {
+        $_SERVER["HTTP_HOST"] = $xForwardedHosts[0];
+        $_SERVER["SERVER_NAME"] = $xForwardedHosts[0];
+    }
 }
 
 // The default cache directory


### PR DESCRIPTION
ignore non valid hostname in HTTP_X_FORWARDED_HOST header (same regex as [the server](https://github.com/kaltura/server/blob/Rigel-18.6.0/infra/storage/file_transfer_managers/asperaMgr.class.php#L81))