### PR TITLE
docs(FEC-12293): update kbind api documentation

### DIFF
--- a/docs/content_api.php
+++ b/docs/content_api.php
@@ -458,9 +458,8 @@ such as the video is playing or is paused.</p>
 kWidget.addReadyCallback(function( playerId ){
 	var kdp = document.getElementById( playerId );
 	// binds an event and namespces it to "myPluginName"
-	kdp.kBind("playerUpdatePlayhead.myPluginName", function( data, id ){
+	kdp.kBind("playerUpdatePlayhead.myPluginName", function( data ){
 		// data = the player's progress time in seconds
-		// id = the ID of the player that fired the notification
 	});
 });
 </pre>


### PR DESCRIPTION
**the issue:**
there is a mismatch between the documentation and what actually happens; callback function do not pass "id" parameter, but only the time value.

**solution:**
need to remove "id" from the callback function in the documentation.

Solves FEC-11293