### PR TITLE
fix(FEC-12265): v2 Share button generates mostly blank email, due to Ampersand

### DIFF
--- a/modules/KalturaSupport/components/share/share.js
+++ b/modules/KalturaSupport/components/share/share.js
@@ -498,7 +498,10 @@
 
 			var embedPlayer = this.getPlayer();
 			var url = network.url;
-			url = decodeURIComponent(url);        // url was encoded to keep curly brackets for template tokens
+			url = decodeURIComponent(url); 		// url was encoded to keep curly brackets for template tokens
+			if(network.id === 'email'){
+				url = url.replace(/{mediaProxy.entry.name}/g, encodeURIComponent(this.getPlayer().evaluate("{mediaProxy.entry.name}")));
+			}
 			url = this.getPlayer().evaluate(url); // replace tokens
 			url = url.replace('#','%23'); // encode hash sign to keep time offset
 			var networks = this.getConfig('shareConfig');


### PR DESCRIPTION
**the issue:** 
Whenever a title of an entry is including ampersand (&) in it, the generated New e-mail is cutting everything after that symbol.
**the solution:**
encoding entry name

solves FEC-12265