### PR TITLE
fix(FEC-12319): player showing out of schedule message even there is admin ks

### DIFF
--- a/modules/KalturaSupport/EntryResult.php
+++ b/modules/KalturaSupport/EntryResult.php
@@ -440,8 +440,8 @@ class EntryResult
             return "No KS where KS is required\nWe're sorry, access to this content is restricted.";
         }
 
-        if (isset($accessControl['isScheduledNow']) &&
-            ($accessControl['isScheduledNow'] === 0 || $accessControl['isScheduledNow'] === false)
+        if (!(isset( $accessControl['isAdmin']) && $accessControl['isAdmin']) &&
+            isset($accessControl['isScheduledNow']) && ($accessControl['isScheduledNow'] === 0 || $accessControl['isScheduledNow'] === false)
         ) {
             return "Out of scheduling\nWe're sorry, this content is currently unavailable.";
         }

--- a/modules/KalturaSupport/resources/mw.KWidgetSupport.js
+++ b/modules/KalturaSupport/resources/mw.KWidgetSupport.js
@@ -1300,7 +1300,7 @@ mw.KWidgetSupport.prototype = {
 		if( ac.isCountryRestricted ){
 			return embedPlayer.getKalturaMsgObject( 'UNAUTHORIZED_COUNTRY' );
 		}
-		if( ac.isScheduledNow === 0 ){
+		if( ac.isScheduledNow === 0 && !ac.isAdmin){
 			return embedPlayer.getKalturaMsgObject( 'OUT_OF_SCHEDULING' );
 		}
 		if( ac.isIpAddressRestricted ) {


### PR DESCRIPTION
**the issue:**
when entry is scheduling not for now the message "out of scheduling" appear even in the kmc or passing ks admin.

**the solution:**
if there is ks admin the message "out of scheduling" doesn't appear and the entry plays as expected.

solves FEC-12319