### PR TITLE
fix(FEC-12322): add alternatives to getReferer logic

### DIFF
--- a/modules/KalturaSupport/RequestHelper.php
+++ b/modules/KalturaSupport/RequestHelper.php
@@ -209,13 +209,33 @@ class RequestHelper {
 		if( $wgKalturaForceReferer !== false ){
 			return $wgKalturaForceReferer;
 		}
-		if( isset( $_SERVER['HTTP_REFERER'] ) ){
-			$urlParts = parse_url( $_SERVER['HTTP_REFERER'] );
-			if (isset( $urlParts['scheme'] ) &&  isset( $urlParts['host']) ) {
-				return $urlParts['scheme'] . "://" . $urlParts['host'] . "/";
-			}
+		if (isset( $_SERVER['HTTP_REFERER'] )){
+            $refererUrl = $this->buildReferer($_SERVER['HTTP_REFERER']);
+        } else if (isset( $_SERVER ) && isset($_SERVER['HTTP_HOST'])) {
+            if ( isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') {
+                $refererUrl = "https://";
+            } else {
+                $refererUrl = "http://";
+            }
+            $refererUrl.= $_SERVER['HTTP_HOST'];
+        } else {
+            $requestHeaders = getallheaders();
+            if( isset( $requestHeaders ) && isset( $requestHeaders['Referer'] ) ){
+                $refererUrl = $this->buildReferer($requestHeaders['Referer']);
+            }
+        }
+		if (isset ($refererUrl) && $refererUrl !== null) {
+		    return $refererUrl;
 		}
 		return 'http://www.kaltura.com/';
+	}
+
+	private function buildReferer($refererUrl) {
+	    $urlParts = parse_url( $refererUrl );
+        if (isset( $urlParts['scheme'] ) &&  isset( $urlParts['host']) ) {
+            return $urlParts['scheme'] . "://" . $urlParts['host'] . "/";
+        }
+        return null;
 	}
 
 	// Check if private IP

--- a/modules/KalturaSupport/RequestHelper.php
+++ b/modules/KalturaSupport/RequestHelper.php
@@ -210,32 +210,32 @@ class RequestHelper {
 			return $wgKalturaForceReferer;
 		}
 		if (isset( $_SERVER['HTTP_REFERER'] ) && !empty($_SERVER['HTTP_REFERER'])){
-            $refererUrl = $this->buildReferer($_SERVER['HTTP_REFERER']);
-        } else if (isset( $_SERVER ) && isset($_SERVER['HTTP_HOST'])) {
-            if ( isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') {
-                $refererUrl = "https://";
-            } else {
-                $refererUrl = "http://";
-            }
-            $refererUrl.= $_SERVER['HTTP_HOST'];
-        } else {
-            $requestHeaders = getallheaders();
-            if( isset( $requestHeaders ) && isset( $requestHeaders['Referer'] ) ){
-                $refererUrl = $this->buildReferer($requestHeaders['Referer']);
-            }
-        }
+			$refererUrl = $this->buildReferer($_SERVER['HTTP_REFERER']);
+		} else if (isset( $_SERVER ) && isset($_SERVER['HTTP_HOST'])) {
+			if ( isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') {
+				$refererUrl = "https://";
+			} else {
+				$refererUrl = "http://";
+			}
+			$refererUrl.= $_SERVER['HTTP_HOST'];
+		} else {
+			$requestHeaders = getallheaders();
+			if( isset( $requestHeaders ) && isset( $requestHeaders['Referer'] ) ){
+				$refererUrl = $this->buildReferer($requestHeaders['Referer']);
+			}
+		}
 		if (isset ($refererUrl)) {
-		    return $refererUrl;
+			return $refererUrl;
 		}
 		return 'http://www.kaltura.com/';
 	}
 
 	private function buildReferer($refererUrl) {
-	    $urlParts = parse_url( $refererUrl );
-        if (isset( $urlParts['scheme'] ) &&  isset( $urlParts['host']) ) {
-            return $urlParts['scheme'] . "://" . $urlParts['host'] . "/";
-        }
-        return null;
+		$urlParts = parse_url( $refererUrl );
+		if (isset( $urlParts['scheme'] ) &&  isset( $urlParts['host']) ) {
+			return $urlParts['scheme'] . "://" . $urlParts['host'] . "/";
+		}
+		return null;
 	}
 
 	// Check if private IP

--- a/modules/KalturaSupport/RequestHelper.php
+++ b/modules/KalturaSupport/RequestHelper.php
@@ -209,33 +209,20 @@ class RequestHelper {
 		if( $wgKalturaForceReferer !== false ){
 			return $wgKalturaForceReferer;
 		}
-		if (isset( $_SERVER['HTTP_REFERER'] ) && !empty($_SERVER['HTTP_REFERER'])){
-			$refererUrl = $this->buildReferer($_SERVER['HTTP_REFERER']);
-		} else if (isset( $_SERVER ) && isset($_SERVER['HTTP_HOST'])) {
+		if (!empty($_SERVER['HTTP_REFERER'])){
+		    $urlParts = parse_url( $_SERVER['HTTP_REFERER'] );
+		    if (isset( $urlParts['scheme'] ) &&  isset( $urlParts['host']) ) {
+		        return $urlParts['scheme'] . "://" . $urlParts['host'] . "/";
+		    }
+		} else if (!empty($_SERVER['HTTP_HOST'])) {
 			if ( isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') {
-				$refererUrl = "https://";
+				$scheme = "https://";
 			} else {
-				$refererUrl = "http://";
+				$scheme = "http://";
 			}
-			$refererUrl.= $_SERVER['HTTP_HOST'];
-		} else {
-			$requestHeaders = getallheaders();
-			if( isset( $requestHeaders ) && isset( $requestHeaders['Referer'] ) ){
-				$refererUrl = $this->buildReferer($requestHeaders['Referer']);
-			}
-		}
-		if (isset ($refererUrl)) {
-			return $refererUrl;
+			return $scheme . $_SERVER['HTTP_HOST'];
 		}
 		return 'http://www.kaltura.com/';
-	}
-
-	private function buildReferer($refererUrl) {
-		$urlParts = parse_url( $refererUrl );
-		if (isset( $urlParts['scheme'] ) &&  isset( $urlParts['host']) ) {
-			return $urlParts['scheme'] . "://" . $urlParts['host'] . "/";
-		}
-		return null;
 	}
 
 	// Check if private IP

--- a/modules/KalturaSupport/RequestHelper.php
+++ b/modules/KalturaSupport/RequestHelper.php
@@ -209,7 +209,7 @@ class RequestHelper {
 		if( $wgKalturaForceReferer !== false ){
 			return $wgKalturaForceReferer;
 		}
-		if (isset( $_SERVER['HTTP_REFERER'] )){
+		if (isset( $_SERVER['HTTP_REFERER'] ) && !empty($_SERVER['HTTP_REFERER'])){
             $refererUrl = $this->buildReferer($_SERVER['HTTP_REFERER']);
         } else if (isset( $_SERVER ) && isset($_SERVER['HTTP_HOST'])) {
             if ( isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') {
@@ -224,7 +224,7 @@ class RequestHelper {
                 $refererUrl = $this->buildReferer($requestHeaders['Referer']);
             }
         }
-		if (isset ($refererUrl) && $refererUrl !== null) {
+		if (isset ($refererUrl)) {
 		    return $refererUrl;
 		}
 		return 'http://www.kaltura.com/';


### PR DESCRIPTION
add alternatives to getReferer logic.

**the issue:**
in some cases, OSs/browsers, for example, OS X/Safari, will not pass $_SERVER['HTTP_REFERER'] and then the fallback would be 'http://www.kaltura.com/'. If a customer is using an ACP where certain domains are allowed (excluding kaltura.com) and the browser did not pass the HTTP_REFERER, then the player will display an error.

**solution:**
add alternatives to get/create the referer.

Solves FEC-12322