### PR TITLE
fix(FEC-12322): add alternatives to getReferer logic 

### DIFF
--- a/modules/KalturaSupport/RequestHelper.php
+++ b/modules/KalturaSupport/RequestHelper.php
@@ -209,11 +209,18 @@ class RequestHelper {
 		if( $wgKalturaForceReferer !== false ){
 			return $wgKalturaForceReferer;
 		}
-		if( isset( $_SERVER['HTTP_REFERER'] ) ){
-			$urlParts = parse_url( $_SERVER['HTTP_REFERER'] );
-			if (isset( $urlParts['scheme'] ) &&  isset( $urlParts['host']) ) {
-				return $urlParts['scheme'] . "://" . $urlParts['host'] . "/";
+		if (!empty($_SERVER['HTTP_REFERER'])){
+		    $urlParts = parse_url( $_SERVER['HTTP_REFERER'] );
+		    if (isset( $urlParts['scheme'] ) &&  isset( $urlParts['host']) ) {
+		        return $urlParts['scheme'] . "://" . $urlParts['host'] . "/";
+		    }
+		} else if (!empty($_SERVER['HTTP_HOST'])) {
+			if ( isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') {
+				$scheme = "https://";
+			} else {
+				$scheme = "http://";
 			}
+			return $scheme . $_SERVER['HTTP_HOST'];
 		}
 		return 'http://www.kaltura.com/';
 	}


### PR DESCRIPTION
add alternatives to getReferer logic.

**the issue:**
in some cases, OSs/browsers, for example, OS X/Safari, will not pass $_SERVER['HTTP_REFERER'] and then the fallback would be 'http://www.kaltura.com/'. If a customer is using an ACP where certain domains are allowed (excluding kaltura.com) and the browser did not pass the HTTP_REFERER, then the player will display an error.

**solution:**
add alternatives to get/create the referer.

Solves FEC-12322