### PR TITLE
fix(FEC-12322): add alternatives to getReferer logic

### DIFF
--- a/kWidget/kWidget.js
+++ b/kWidget/kWidget.js
@@ -2188,6 +2188,9 @@
 				params += '&' + 'flashvars[' + encodeURIComponent(i) + ']=' +
 					encodeURIComponent(curVal);
 			}
+			// add fallbackParentUrl flashvar - SUP-32821
+			params += '&' + 'flashvars[' + encodeURIComponent('fallbackToParentReferer') + ']=' +
+				encodeURIComponent( document.URL);
 			return params;
 		},
 		/**

--- a/kWidget/kWidget.js
+++ b/kWidget/kWidget.js
@@ -2189,8 +2189,7 @@
 					encodeURIComponent(curVal);
 			}
 			// add fallbackParentUrl flashvar - SUP-32821
-			params += '&' + 'flashvars[' + encodeURIComponent('fallbackToParentReferer') + ']=' +
-				encodeURIComponent( document.URL);
+			params += '&flashvars[fallbackToParentReferer]=' + encodeURIComponent( document.URL);
 			return params;
 		},
 		/**

--- a/kWidget/kWidget.js
+++ b/kWidget/kWidget.js
@@ -2188,7 +2188,7 @@
 				params += '&' + 'flashvars[' + encodeURIComponent(i) + ']=' +
 					encodeURIComponent(curVal);
 			}
-			// add fallbackParentUrl flashvar - SUP-32821
+			// add parentDomain flashvar - SUP-32821
 			params += '&' + 'flashvars[' + encodeURIComponent('parentDomain') + ']=' +
 				encodeURIComponent( document.URL);
 			return params;

--- a/kWidget/kWidget.js
+++ b/kWidget/kWidget.js
@@ -2189,7 +2189,7 @@
 					encodeURIComponent(curVal);
 			}
 			// add fallbackParentUrl flashvar - SUP-32821
-			params += '&' + 'flashvars[' + encodeURIComponent('fallbackToParentReferer') + ']=' +
+			params += '&' + 'flashvars[' + encodeURIComponent('parentDomain') + ']=' +
 				encodeURIComponent( document.URL);
 			return params;
 		},

--- a/kWidget/kWidget.js
+++ b/kWidget/kWidget.js
@@ -2189,7 +2189,8 @@
 					encodeURIComponent(curVal);
 			}
 			// add fallbackParentUrl flashvar - SUP-32821
-			params += '&flashvars[fallbackToParentReferer]=' + encodeURIComponent( document.URL);
+			params += '&' + 'flashvars[' + encodeURIComponent('fallbackToParentReferer') + ']=' +
+				encodeURIComponent( document.URL);
 			return params;
 		},
 		/**

--- a/modules/KalturaSupport/EntryResult.php
+++ b/modules/KalturaSupport/EntryResult.php
@@ -365,7 +365,7 @@ class EntryResult
     public function getACFilter()
     {
         $filter = new KalturaEntryContextDataParams();
-        $refererFromPlayer = $this->uiconf->playerConfig['vars']['fallbackToParentReferer'];
+        $refererFromPlayer = $this->uiconf->playerConfig['vars']['parentDomain'];
         $filter->referrer = $this->request->getReferer($refererFromPlayer);
         $filter->userAgent = $this->request->getUserAgent();
         $filter->flavorTags = 'all';

--- a/modules/KalturaSupport/EntryResult.php
+++ b/modules/KalturaSupport/EntryResult.php
@@ -365,7 +365,8 @@ class EntryResult
     public function getACFilter()
     {
         $filter = new KalturaEntryContextDataParams();
-        $filter->referrer = $this->request->getReferer();
+        $refererFromPlayer = $this->uiconf->playerConfig['vars']['fallbackToParentReferer'];
+        $filter->referrer = $this->request->getReferer($refererFromPlayer);
         $filter->userAgent = $this->request->getUserAgent();
         $filter->flavorTags = 'all';
         if ($this->uiconf->getPlayerConfig(false, 'flavorTags')) {

--- a/modules/KalturaSupport/RequestHelper.php
+++ b/modules/KalturaSupport/RequestHelper.php
@@ -7,7 +7,7 @@ class RequestHelper {
 	var $debug = false;
 	var $utility = null;
 
-    var $EXCLUDE_ESCAPED_ATTRIBUTES = array('flashvars');
+	var $EXCLUDE_ESCAPED_ATTRIBUTES = array('flashvars');
 
 	/**
 	 * Variables set by the Frame request:
@@ -60,10 +60,10 @@ class RequestHelper {
 			foreach( $urlParts as $inx => $urlPart ){
 				foreach( $this->urlParameters as $attributeKey => $na){
 					if( $urlPart == $attributeKey && isset( $urlParts[$inx+1] ) ){
-					    $data = $urlParts[$inx+1];
-					    if (!in_array($attributeKey, $this->EXCLUDE_ESCAPED_ATTRIBUTES)) {
-					        $data = htmlspecialchars( $urlParts[$inx+1], ENT_QUOTES );
-					    }
+						$data = $urlParts[$inx+1];
+						if (!in_array($attributeKey, $this->EXCLUDE_ESCAPED_ATTRIBUTES)) {
+							$data = htmlspecialchars( $urlParts[$inx+1], ENT_QUOTES );
+						}
 						$_REQUEST[ $attributeKey ] = $data;
 					}
 				}
@@ -183,21 +183,21 @@ class RequestHelper {
 	}
 
 	function isEmbedServicesEnabled(){
-	    global $wgEnableKalturaEmbedServicesRouting, $wgKalturaAuthEmbedServicesDomains;
-	    if ($wgEnableKalturaEmbedServicesRouting){
-	        return true;
-	    } else {
-	        return false;
-        }
+		global $wgEnableKalturaEmbedServicesRouting, $wgKalturaAuthEmbedServicesDomains;
+		if ($wgEnableKalturaEmbedServicesRouting){
+			return true;
+		} else {
+			return false;
+		}
 	}
 
 	function isEmbedServicesRequest(){
-	    $proxyData = $this->getFlashVars("proxyData");
-        return (isset($proxyData) && !empty($proxyData));
-    }
+		$proxyData = $this->getFlashVars("proxyData");
+		return (isset($proxyData) && !empty($proxyData));
+	}
 
 	function getEmbedServicesRequest(){
-	    return $this->getFlashVars("proxyData");
+		return $this->getFlashVars("proxyData");
 	}
 
 	public function getUserAgent() {
@@ -211,25 +211,25 @@ class RequestHelper {
 		}
 		$refererUrl = '';
 		if (!empty($_SERVER['HTTP_REFERER'])) {
-		    $refererUrl = $this->buildReferer($_SERVER['HTTP_REFERER']);
+			$refererUrl = $this->buildReferer($_SERVER['HTTP_REFERER']);
 		}
 		// buildReferer might return null
 		if (empty($refererUrl) && !empty($refererFromPlayer)) {
-            $refererUrl = $this->buildReferer($refererFromPlayer);
+			$refererUrl = $this->buildReferer($refererFromPlayer);
 		}
 		// buildReferer might return null
-        if (empty($refererUrl)) {
-            $refererUrl = 'http://www.kaltura.com/';
-        }
-        return $refererUrl;
+		if (empty($refererUrl)) {
+			$refererUrl = 'http://www.kaltura.com/';
+		}
+		return $refererUrl;
 	}
 
 	private function buildReferer($refererUrl) {
-	    $urlParts = parse_url( $refererUrl );
-        if (isset( $urlParts['scheme'] ) &&  isset( $urlParts['host']) ) {
-            return $urlParts['scheme'] . "://" . $urlParts['host'] . "/";
-        }
-        return null;
+		$urlParts = parse_url( $refererUrl );
+		if (isset( $urlParts['scheme'] ) &&  isset( $urlParts['host']) ) {
+			return $urlParts['scheme'] . "://" . $urlParts['host'] . "/";
+		}
+		return null;
 	}
 
 	// Check if private IP
@@ -285,7 +285,7 @@ class RequestHelper {
 		return $remote_addr;
 	}
 
- 	public function getRemoteAddrHeader(){
+	public function getRemoteAddrHeader(){
 		global $wgKalturaRemoteAddressSalt, $wgKalturaForceIP;
 		if( $wgKalturaRemoteAddressSalt === false ){
 			return '';

--- a/modules/KalturaSupport/RequestHelper.php
+++ b/modules/KalturaSupport/RequestHelper.php
@@ -204,25 +204,32 @@ class RequestHelper {
 		return isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : '';
 	}
 
-	public function getReferer(){
+	public function getReferer($refererFromPlayer = null){
 		global $wgKalturaForceReferer;
 		if( $wgKalturaForceReferer !== false ){
 			return $wgKalturaForceReferer;
 		}
-		if (!empty($_SERVER['HTTP_REFERER'])){
-		    $urlParts = parse_url( $_SERVER['HTTP_REFERER'] );
-		    if (isset( $urlParts['scheme'] ) &&  isset( $urlParts['host']) ) {
-		        return $urlParts['scheme'] . "://" . $urlParts['host'] . "/";
-		    }
-		} else if (!empty($_SERVER['HTTP_HOST'])) {
-			if ( isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') {
-				$scheme = "https://";
-			} else {
-				$scheme = "http://";
-			}
-			return $scheme . $_SERVER['HTTP_HOST'];
+		$refererUrl = '';
+		if (!empty($_SERVER['HTTP_REFERER'])) {
+		    $refererUrl = $this->buildReferer($_SERVER['HTTP_REFERER']);
 		}
-		return 'http://www.kaltura.com/';
+		// buildReferer might return null
+		if (empty($refererUrl) && !empty($refererFromPlayer)) {
+            $refererUrl = $this->buildReferer($refererFromPlayer);
+		}
+		// buildReferer might return null
+        if (empty($refererUrl)) {
+            $refererUrl = 'http://www.kaltura.com/';
+        }
+        return $refererUrl;
+	}
+
+	private function buildReferer($refererUrl) {
+	    $urlParts = parse_url( $refererUrl );
+        if (isset( $urlParts['scheme'] ) &&  isset( $urlParts['host']) ) {
+            return $urlParts['scheme'] . "://" . $urlParts['host'] . "/";
+        }
+        return null;
 	}
 
 	// Check if private IP


### PR DESCRIPTION
**the issue:**
in some cases, browsers, for example, Safari, will not pass $_SERVER['HTTP_REFERER'] and then the fallback would be 'http://www.kaltura.com/'. If a customer is using an ACP where certain domains are allowed (excluding kaltura.com) and the browser did not pass the HTTP_REFERER, then the player will display an error.

**solution:**
pass parentDomain as uiconf var to server side with value of document.URL and use it as an alternative when the server side is getting the referer.

Solves [FEC-12322](https://kaltura.atlassian.net/browse/FEC-12322)