### PR TITLE
fix(FEC-12328): android fullscreen not working using iframe embed

### DIFF
--- a/modules/MwEmbedSupport/mediawiki/mediawiki.client.js
+++ b/modules/MwEmbedSupport/mediawiki/mediawiki.client.js
@@ -149,7 +149,7 @@
 		return ( mw.isAndroid() && mw.isChrome() );
 	};
 	mw.isOldAndroidChromeNativeBrowser = function () {
-		var regExpResult = userAgent.match(/Chrome\/([0-9][0-9])/);
+		var regExpResult = userAgent.match(/Chrome\/([0-9][0-9]+)/);
 		if ( regExpResult instanceof Array && regExpResult.length > 1 ){
 			return mw.isAndroidChromeNativeBrowser() && parseInt( regExpResult[1] ) < 30;
 		}


### PR DESCRIPTION
**the issue:**
when using iframe embed in Android/Chrome -> the fullscreen does not work.

**root cause:**
in mediawiki we check for android chrome version, since the regex matches only versions with 2 digits,for new Chrome version (100+) which have 3 digits, the player thinks it's an old one. example: for Chrome/102.0.0.0 the regex returns version "10" instead of "102".

**solution:**
change regex to also fit 3 digits versions.

Solves FEC-12328