### PR TITLE
fix(FEC-12332): video share to LinkedIn cut out the query parameters

### DIFF
--- a/modules/KalturaSupport/components/share/share.js
+++ b/modules/KalturaSupport/components/share/share.js
@@ -502,6 +502,9 @@
 			if(network.id === 'email'){
 				url = url.replace(/{mediaProxy.entry.name}/g, encodeURIComponent(this.getPlayer().evaluate("{mediaProxy.entry.name}")));
 			}
+			if(network.id === 'linkedin'){
+				url = url.replace(/{share.shareURL}/g, encodeURIComponent(this.getPlayer().evaluate("{share.shareURL}")));
+			}
 			url = this.getPlayer().evaluate(url); // replace tokens
 			url = url.replace('#','%23'); // encode hash sign to keep time offset
 			var networks = this.getConfig('shareConfig');


### PR DESCRIPTION
**the issue:**
when use a custom socialShareUrl with query parameter at the end of the url, the linkedin share popup cut out the query parameters. 

**the solation:**
added encoding for the linkedin share url.

solves FEC-12332