### PR TITLE
fix(FEC-12371): multiaudio with live does not switch back to first audio track in Safari

### DIFF
--- a/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
+++ b/modules/EmbedPlayer/resources/mw.EmbedPlayerNative.js
@@ -1659,7 +1659,9 @@
 		switchAudioTrack: function(audioTrackIndex){
 			var vid  = this.getPlayerElement();
 			var audioTracks = vid.audioTracks;
-			if(audioTracks && audioTracks[audioTrackIndex] && !audioTracks[audioTrackIndex].enabled) {
+			if(audioTracks && audioTracks[audioTrackIndex]) {
+				// need to first disable all audioTracks
+				this.disableAudioTracks(audioTracks);
 				if(mw.isEdge()){
 
 					// Edge has a problem to switch audio track at playback time, so as a workaround - pause before the switching.
@@ -1685,6 +1687,13 @@
 					audioTracks[audioTrackIndex].enabled = true;
 				}
 				this.audioTrackIndex = audioTrackIndex;
+			}
+		},
+		disableAudioTracks: function(audioTracks) {
+			if (audioTracks) {
+				for (var i = 0; i < audioTracks.length; i++) {
+					audioTracks[i].enabled = false;
+				}
 			}
 		},
 		onSwitchTextTrack: function (event, data) {


### PR DESCRIPTION
**the issue:**
safari native player is not setting to false the audioTrack.enabled of the first item in audioTracks list.

**solution:**
disable all audioTracks before setting current one to enable.

Solves FEC-12371