### PR TITLE
fix(FEC-12397): transcript and captions are not displaying on iPhones when ACP is enabled

### DIFF
--- a/modules/MwEmbedSupport/mediawiki/mediawiki.ajaxProxy.js
+++ b/modules/MwEmbedSupport/mediawiki/mediawiki.ajaxProxy.js
@@ -70,6 +70,11 @@
 				};
 			}
 
+			// include referer if exists
+			if (_this.options.headers) {
+				ajaxOptions.headers = _this.options.headers;
+			}
+
 			// make the request
 			try {
 				$.ajax( ajaxOptions );

--- a/modules/TimedText/resources/mw.TextSource.js
+++ b/modules/TimedText/resources/mw.TextSource.js
@@ -77,7 +77,7 @@
 			// Check type for special loaders:
 			$( mw ).triggerQueueCallback( 'TimedText_LoadTextSource', _this, function(){
 				// if no module loaded the text source use the normal ajax proxy:
-				new mw.ajaxProxy({
+				var request = {
 					url: _this.getSrc(),
 					success: function( resultXML ) {
 						_this.captions = _this.getCaptions( resultXML );
@@ -90,7 +90,11 @@
 						_this.loaded = true;
 						callback();
 					}
-				});
+				};
+				if (mw.isIOS() && mw.isSafari() && document.URL) {
+					request.headers = {'X-Alt-Referer': document.URL };
+				}
+				new mw.ajaxProxy(request);
 			});
 		},
 


### PR DESCRIPTION
**the issue:**
when playing an entry on iOS/Safari and an ACP is enabled and applied on that entry, the BE does not return the captions and there is an error about the access control.

**root cause:**
Safari doesn't pass referer.

**solution:**
add referer header to the ajax captions request.

Solves FEC-12397