### PR TITLE
fix(FEC-12512): unmute button opens the ad url when using Bumper

### DIFF
--- a/modules/unMuteOverlayButton/resources/unMuteOverlayButton.js
+++ b/modules/unMuteOverlayButton/resources/unMuteOverlayButton.js
@@ -52,9 +52,9 @@
 
                 // when clicking on current component and there is a click.adClick event, we don't want to let it bubble
                 // the goal for this component is just to do unmute when clicking on it
-                this.getComponent().bind('click.adClick', function (e) {
-                    e.stopPropagation();
-                    e.preventDefault();
+                this.getComponent().bind('click.adClick', function (event) {
+                    event.stopPropagation();
+                    event.preventDefault();
                 });
             },
 

--- a/modules/unMuteOverlayButton/resources/unMuteOverlayButton.js
+++ b/modules/unMuteOverlayButton/resources/unMuteOverlayButton.js
@@ -49,6 +49,13 @@
                         });
                     }
                 }.bind(this));
+
+                // when clicking on current component and there is a click.adClick event, we don't want to let it bubble
+                // the goal for this component is just to do unmute when clicking on it
+                this.getComponent().bind('click.adClick', function (e) {
+                    e.stopPropagation();
+                    e.preventDefault();
+                });
             },
 
             show: function () {


### PR DESCRIPTION
**background:**
when using bumper plugin, there is an option to configure a url that will be opened in a new window, whenever clicking on the bumper video.

**the issue:**
when configuring an adUrl in bumper plugin, clicking on the unmuteOverlayButton will open the url in a new window. expected behavior is to only do the unmute, without opening the ad url.

**the root cause:**
the videoHolder element is listening to the adClick event; the unmuteOverlayButton is a child element of videoHolder, hence, whenever clicking on the unmute button the adClick event is being triggered and a new window with the configured url is being opened.

**solution:**
bind the unmuteOverlayButton to the adClick event and stop propagation.

Solves FEC-12512
