### PR TITLE
fix(FEC-12575): YouTube entries time counter issue

### DIFF
--- a/modules/ExternalPlayers/resources/mw.EmbedPlayerYouTube.js
+++ b/modules/ExternalPlayers/resources/mw.EmbedPlayerYouTube.js
@@ -197,6 +197,7 @@
                         // update the playhead status
                         this.updatePlayheadStatus();
                     }
+					this.monitor();
                     break;
                 case YT.PlayerState.PAUSED:
                     stateName = "paused";
@@ -503,7 +504,6 @@
 						});
 					}
 				}
-				this.monitor();
 			}
 		},
 


### PR DESCRIPTION
**the issue:**
when click on the player element to play the video (not click on the play buttons) the video play well but the time counter and the seekbar is stuck and doesn't move.

**the root cause:** 
the monitor function is called only when play the video from the buttons.

**the solution:**
call to the monitor function when the video is playing, not matter how the video is turn on.
