### PR TITLE
Reflected XSS Vulnerability on rss.php

### DIFF
--- a/docs/rss.php
+++ b/docs/rss.php
@@ -22,7 +22,7 @@ echo $docsRss;
 
 function generate_docs_rss(){
 	global $wgGitRepoPath ;
-	$baseUrl = 'http://' . $_SERVER['HTTP_HOST'] . str_replace('rss.php', '', $_SERVER['REQUEST_URI']);
+	$baseUrl = 'http://' . $_SERVER['SERVER_NAME'] . str_replace('rss.php', '', $_SERVER['REQUEST_URI']);
 	ob_start();
 ?>
 <rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">


### PR DESCRIPTION
Fix for a Reflected XSS vulnerability. Attackers can add the X-Forwarded-Host header to inject XSS payloads.

 X-Forwarded-Host: <script>alert(document.cookie)</script>

This mitigation prevents  X-Forwarded-Host from being modified.