### PR TITLE
fix(FEC-12600): player should support referer without scheme part

### DIFF
--- a/modules/KalturaSupport/RequestHelper.php
+++ b/modules/KalturaSupport/RequestHelper.php
@@ -229,6 +229,8 @@ class RequestHelper {
 		$urlParts = parse_url( $refererUrl );
 		if (isset( $urlParts['scheme'] ) &&  isset( $urlParts['host']) ) {
 			return $urlParts['scheme'] . "://" . $urlParts['host'] . "/";
+		} else if (isset($urlParts['path']) ) {
+		    return $urlParts['path'] . "/";
 		}
 		return null;
 	}


### PR DESCRIPTION
**the issue:**
sometimes referer header might not include "http" or "https" (i.e. kaltura.com). in this case, if kaltura.com is an allowed domain in an ACP, it will not be recognized by the player, since the player is looking for "scheme" part (http/s) and "host" part. we are using an php function called parse_url to break the referer header into url parts. in cases where the referer does not contain a scheme part (http/s), there is also no host, but "path" exists instead.

**solution:**
when building the referer, adding another check for "path" attribute.

Solves FEC-12600