### PR TITLE
fix(FEC-12891): Play Button and CC option not accessible.

### DIFF
--- a/modules/KalturaSupport/components/largePlayBtn.js
+++ b/modules/KalturaSupport/components/largePlayBtn.js
@@ -147,7 +147,7 @@
 				var eventName = 'click';
 				this.$el = $( '<a />' )
 					.attr( {
-						'tabindex': '-1',
+						'tabindex': '1',
 						'href' : '#',
 						'role': 'button',
 						'title' : this.playLabel,

--- a/skins/kdark/css/layout.css
+++ b/skins/kdark/css/layout.css
@@ -447,6 +447,10 @@ body {
 	border-radius: 0.1em;
 }
 
+.largePlayBtnBorder:focus {
+	outline: 1px solid #66CCFF;
+}
+
 .scrubber {
 	position: relative;
 	height: 0.6em;


### PR DESCRIPTION
**the issue:**
the large play button in the middle of the player is not accessible with tab key.

**the solution:**
change tabindex to 1

solves FEC-12891