### PR TITLE
fix(FEC-12891): Play Button and CC option not accessible.

### DIFF
--- a/resources/mediawiki/mediawiki.kmenu.js
+++ b/resources/mediawiki/mediawiki.kmenu.js
@@ -80,7 +80,7 @@
 							.attr({
 								'href': '#',
                                 'title': item.label,
-                                'role': 'menuitemcheckbox',
+                                'role': 'menuitem',
                                 'aria-checked': 'false',
 								'tabindex': this.getTabIndex(this.itemIdx + 1)
 							})


### PR DESCRIPTION
**the issue:**
when using JWAS screen reader, it's not possible to use arrow keys to to move between the items in the list (also in the speed and source menu) and it's not read the languages of the captions.

**the solution:**
change the a element role to menuitem

solves FEC-12891