### PR TITLE
fix(FEC-12897): Focus hidden element on page

### DIFF
--- a/modules/KalturaSupport/components/scrubber.js
+++ b/modules/KalturaSupport/components/scrubber.js
@@ -458,6 +458,7 @@
 				// Up the z-index of the default status indicator:
 				this.$el.find('.ui-slider-handle')
 					.addClass('playHead PIE btn')
+					.removeAttr('tabindex')
 					.wrap('<div class="handle-wrapper" />');
 				// Update attributes: 
 				this.updateAttr({ 'value': 0 });


### PR DESCRIPTION
**the issue:**
the playHead button has tabindex=0 and so when move with tab on the player button, after moving all the buttons the tab is focused on the playHead button, although there are no abilities for the focus mode.

**the solution:**
remove the tabindex attribute.