### PR TITLE
fix(SUP-37284): v2 player - Empty Playlist no longer says no videos found

### DIFF
--- a/modules/KalturaSupport/resources/mw.KWidgetSupport.js
+++ b/modules/KalturaSupport/resources/mw.KWidgetSupport.js
@@ -334,10 +334,11 @@ mw.KWidgetSupport.prototype = {
 				} else {
 					deferred.resolve();
 				}
-			}
-			else {
+			} else {
 				deferred.resolve();
 			}
+		} else {
+			deferred.resolve();
 		}
 		return deferred.promise();
 	},


### PR DESCRIPTION
issue:
regression from 2.97 - when playlist empty it show spinner instead of error message

solution:
add promise.resolve in case metadata is empty